### PR TITLE
テスト: リマインダー機能のテストを実装

### DIFF
--- a/src/app/(app)/app/reminder/[id]/edit/__tests__/page.test.tsx
+++ b/src/app/(app)/app/reminder/[id]/edit/__tests__/page.test.tsx
@@ -1,0 +1,306 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import EditReminderPage from '../page'
+import { use } from 'react'
+
+// モック設定
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  use: jest.fn(),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    back: jest.fn(),
+    pathname: '/app/reminder/reminder-1/edit',
+    query: {},
+    asPath: '/app/reminder/reminder-1/edit',
+  }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/app/reminder/reminder-1/edit',
+}))
+
+// グローバルfetchとalertのモック
+global.fetch = jest.fn()
+global.alert = jest.fn()
+
+describe('EditReminderPage', () => {
+  const mockEvents = [
+    {
+      id: 'event-1',
+      name: 'テストイベント1',
+      theme: 'テストテーマ1',
+    },
+    {
+      id: 'event-2',
+      name: 'テストイベント2',
+      theme: null,
+    },
+  ]
+
+  const mockReminder = {
+    id: 'reminder-1',
+    event: {
+      id: 'event-1',
+      name: 'テストイベント1',
+      theme: 'テストテーマ1',
+    },
+    label: 'エントリー締切',
+    datetime: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    note: 'テスト備考',
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(global.fetch as jest.Mock).mockClear()
+    ;(global.alert as jest.Mock).mockClear()
+    ;(use as jest.Mock).mockImplementation(() => {
+      return { id: 'reminder-1' }
+    })
+  })
+
+  it('ローディング状態を表示する', () => {
+    ;(global.fetch as jest.Mock).mockImplementation(() =>
+      new Promise(() => {}) // 解決しないPromiseでローディング状態を維持
+    )
+
+    render(<EditReminderPage params={Promise.resolve({ id: 'reminder-1' })} />)
+    expect(screen.getByLabelText('読み込み中')).toBeInTheDocument()
+  })
+
+  it('リマインダー情報を表示する', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockEvents,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockReminder,
+      })
+
+    render(<EditReminderPage params={Promise.resolve({ id: 'reminder-1' })} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('リマインダーを編集')).toBeInTheDocument()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/エントリー開始、支払期限、集合時間/)).toBeInTheDocument()
+    })
+  })
+
+  it('リマインダーが見つからない場合、エラーメッセージを表示する', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockEvents,
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      })
+
+    render(<EditReminderPage params={Promise.resolve({ id: 'reminder-1' })} />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/リマインダーが見つかりません/)).toBeInTheDocument()
+    })
+  })
+
+  it('フォーム送信でリマインダーを更新する', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockEvents,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockReminder,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      })
+
+    const user = userEvent.setup()
+    render(<EditReminderPage params={Promise.resolve({ id: 'reminder-1' })} />)
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/エントリー開始、支払期限、集合時間/)).toBeInTheDocument()
+    })
+
+    const labelInput = screen.getByPlaceholderText(/エントリー開始、支払期限、集合時間/)
+    await user.clear(labelInput)
+    await user.type(labelInput, '更新されたラベル')
+
+    const submitButton = screen.getByRole('button', { name: /更新/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/reminders/reminder-1',
+        expect.objectContaining({
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    })
+  })
+
+  it('削除ボタンをクリックすると、削除確認モーダルを表示する', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockEvents,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockReminder,
+      })
+
+    const user = userEvent.setup()
+    render(<EditReminderPage params={Promise.resolve({ id: 'reminder-1' })} />)
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/エントリー開始、支払期限、集合時間/)).toBeInTheDocument()
+    })
+
+    const deleteButton = screen.getByRole('button', { name: /削除/i })
+    await user.click(deleteButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('リマインダーを削除')).toBeInTheDocument()
+    })
+  })
+
+  it('削除確認モーダルで削除を実行すると、リマインダーを削除する', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockEvents,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockReminder,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      })
+
+    const user = userEvent.setup()
+    render(<EditReminderPage params={Promise.resolve({ id: 'reminder-1' })} />)
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/エントリー開始、支払期限、集合時間/)).toBeInTheDocument()
+    })
+
+    const deleteButton = screen.getByRole('button', { name: /削除/i })
+    await user.click(deleteButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('リマインダーを削除')).toBeInTheDocument()
+    })
+
+    const confirmButtons = screen.getAllByRole('button', { name: '削除' })
+    const confirmButton = confirmButtons.find(btn => btn.textContent === '削除' && btn.closest('[role="dialog"]')) || confirmButtons[confirmButtons.length - 1]
+    await user.click(confirmButton)
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/reminders/reminder-1',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+  })
+
+  it('更新中はボタンが無効化される', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockEvents,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockReminder,
+      })
+      .mockImplementationOnce(() =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({
+              ok: true,
+              json: async () => ({ success: true }),
+            })
+          }, 100)
+        })
+      )
+
+    const user = userEvent.setup()
+    render(<EditReminderPage params={Promise.resolve({ id: 'reminder-1' })} />)
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/エントリー開始、支払期限、集合時間/)).toBeInTheDocument()
+    })
+
+    const submitButton = screen.getByRole('button', { name: /更新/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('更新中...')).toBeInTheDocument()
+    })
+  })
+
+  it('エラーが発生した場合、エラーメッセージを表示する', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockEvents,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockReminder,
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      })
+
+    const user = userEvent.setup()
+    render(<EditReminderPage params={Promise.resolve({ id: 'reminder-1' })} />)
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/エントリー開始、支払期限、集合時間/)).toBeInTheDocument()
+    })
+
+    const submitButton = screen.getByRole('button', { name: /更新/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(global.alert).toHaveBeenCalledWith('リマインダーの更新に失敗しました')
+    }, { timeout: 3000 })
+  })
+
+  it('リマインダー一覧への戻るリンクを表示する', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockEvents,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockReminder,
+      })
+
+    render(<EditReminderPage params={Promise.resolve({ id: 'reminder-1' })} />)
+
+    await waitFor(() => {
+      const backLink = screen.getByText(/リマインダー一覧に戻る/)
+      expect(backLink.closest('a')).toHaveAttribute('href', '/app/reminder')
+    })
+  })
+})
+

--- a/src/app/(app)/app/reminder/__tests__/page.test.tsx
+++ b/src/app/(app)/app/reminder/__tests__/page.test.tsx
@@ -1,0 +1,325 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ReminderPage from '../page'
+
+// モック設定
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    back: jest.fn(),
+    pathname: '/app/reminder',
+    query: {},
+    asPath: '/app/reminder',
+  }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/app/reminder',
+}))
+
+// グローバルfetchとalertのモック
+global.fetch = jest.fn()
+global.alert = jest.fn()
+
+describe('ReminderPage', () => {
+  const mockReminders = [
+    {
+      id: 'reminder-1',
+      event: {
+        id: 'event-1',
+        name: 'テストイベント1',
+        theme: 'テストテーマ1',
+        event_date: '2024-12-31T10:00:00Z',
+        original_url: 'https://example.com/event1',
+      },
+      type: 'entry_deadline',
+      datetime: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(), // 24時間後
+      label: 'エントリー締切',
+      notified: false,
+      notified_at: null,
+      created_at: '2024-01-01T00:00:00Z',
+    },
+    {
+      id: 'reminder-2',
+      event: null,
+      type: 'custom',
+      datetime: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(), // 24時間前
+      label: '過去のリマインダー',
+      notified: true,
+      notified_at: '2024-01-01T00:00:00Z',
+      created_at: '2024-01-01T00:00:00Z',
+    },
+  ]
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(global.fetch as jest.Mock).mockClear()
+    ;(global.alert as jest.Mock).mockClear()
+  })
+
+  it('ローディング状態を表示する', () => {
+    ;(global.fetch as jest.Mock).mockImplementation(() =>
+      new Promise(() => {}) // 解決しないPromiseでローディング状態を維持
+    )
+
+    render(<ReminderPage />)
+    expect(screen.getByLabelText('読み込み中')).toBeInTheDocument()
+  })
+
+  it('リマインダー一覧を表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockReminders,
+    })
+
+    render(<ReminderPage />)
+
+    await waitFor(() => {
+      expect(screen.getAllByText('エントリー締切').length).toBeGreaterThan(0)
+    })
+
+    expect(screen.getAllByText('過去のリマインダー').length).toBeGreaterThan(0)
+  })
+
+  it('リマインダーが空の場合、空のメッセージを表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    })
+
+    render(<ReminderPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/リマインダーが登録されていません/)).toBeInTheDocument()
+    })
+  })
+
+  it('今後のリマインダーと過去のリマインダーを分けて表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockReminders,
+    })
+
+    render(<ReminderPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('今後のリマインダー')).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('heading', { name: '過去のリマインダー' })).toBeInTheDocument()
+  })
+
+  it('イベント情報を表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockReminders,
+    })
+
+    render(<ReminderPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('テストイベント1')).toBeInTheDocument()
+    })
+  })
+
+  it('通知済みバッジを表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockReminders,
+    })
+
+    render(<ReminderPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('通知済み')).toBeInTheDocument()
+    })
+  })
+
+  it('ソート機能を表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockReminders,
+    })
+
+    render(<ReminderPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ソート:')).toBeInTheDocument()
+    })
+
+    expect(screen.getByDisplayValue('期日が近い順（昇順）')).toBeInTheDocument()
+  })
+
+  it('ソート順を変更すると、ソート順でAPIを呼び出す', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockReminders,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockReminders,
+      })
+
+    const user = userEvent.setup()
+    render(<ReminderPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ソート:')).toBeInTheDocument()
+    })
+
+    const sortSelect = screen.getByDisplayValue('期日が近い順（昇順）')
+    await user.selectOptions(sortSelect, 'desc')
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('sortOrder=desc')
+      )
+    })
+  })
+
+  it('新規作成ボタンを表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockReminders,
+    })
+
+    render(<ReminderPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('新規作成')).toBeInTheDocument()
+    })
+  })
+
+  it('新規作成ボタンがリンクになっている', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockReminders,
+    })
+
+    render(<ReminderPage />)
+
+    await waitFor(() => {
+      const createButton = screen.getByText('新規作成').closest('a')
+      expect(createButton).toHaveAttribute('href', '/app/reminder/new')
+    })
+  })
+
+  it('削除ボタンをクリックすると、削除確認モーダルを表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockReminders,
+    })
+
+    const user = userEvent.setup()
+    render(<ReminderPage />)
+
+    await waitFor(() => {
+      expect(screen.getAllByText('エントリー締切').length).toBeGreaterThan(0)
+    })
+
+    // ShareMenuのメニューボタンをクリックしてから削除ボタンを探す
+    const menuButtons = screen.getAllByTitle('メニュー')
+    if (menuButtons.length > 0) {
+      await user.click(menuButtons[0])
+      
+      // メニューが開いたら削除ボタンを探す
+      await waitFor(async () => {
+        const deleteButtons = screen.queryAllByText(/削除/)
+        if (deleteButtons.length > 0) {
+          await user.click(deleteButtons[0])
+        }
+      }, { timeout: 2000 })
+    }
+
+    await waitFor(() => {
+      expect(screen.getByText('リマインダーを削除')).toBeInTheDocument()
+    }, { timeout: 3000 })
+  })
+
+  it('削除確認モーダルで削除を実行すると、リマインダーを削除する', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockReminders,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [mockReminders[1]], // 削除後のリスト
+      })
+
+    const user = userEvent.setup()
+    render(<ReminderPage />)
+
+    await waitFor(() => {
+      expect(screen.getAllByText('エントリー締切').length).toBeGreaterThan(0)
+    })
+
+    // ShareMenuのメニューボタンをクリック
+    const menuButtons = screen.getAllByTitle('メニュー')
+    if (menuButtons.length > 0) {
+      await user.click(menuButtons[0])
+      
+      // メニューが開いたら削除ボタンを探す
+      await waitFor(async () => {
+        const deleteButtons = screen.queryAllByText(/削除/)
+        if (deleteButtons.length > 0) {
+          await user.click(deleteButtons[0])
+        }
+      }, { timeout: 2000 })
+    }
+
+    await waitFor(() => {
+      expect(screen.getByText('リマインダーを削除')).toBeInTheDocument()
+    }, { timeout: 3000 })
+
+    const confirmButton = screen.getByText('削除')
+    await user.click(confirmButton)
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/reminders/reminder-1',
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    }, { timeout: 3000 })
+  })
+
+  it('マイページへの戻るリンクを表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockReminders,
+    })
+
+    render(<ReminderPage />)
+
+    await waitFor(() => {
+      const backLink = screen.getByText(/マイページへ戻る/)
+      expect(backLink.closest('a')).toHaveAttribute('href', '/app/mypage')
+    })
+  })
+
+  it('エラーが発生した場合、エラーログを出力する', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+    ;(global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'))
+
+    render(<ReminderPage />)
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalled()
+    }, { timeout: 3000 })
+
+    // エラーメッセージが含まれることを確認
+    const errorCalls = consoleErrorSpy.mock.calls
+    const hasReminderError = errorCalls.some(call => 
+      call[0]?.toString().includes('Failed to fetch reminders')
+    )
+    expect(hasReminderError).toBe(true)
+
+    consoleErrorSpy.mockRestore()
+  })
+})
+

--- a/src/app/(app)/app/reminder/new/__tests__/page.test.tsx
+++ b/src/app/(app)/app/reminder/new/__tests__/page.test.tsx
@@ -1,0 +1,289 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import NewReminderPage from '../page'
+
+// モック設定
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    back: jest.fn(),
+    pathname: '/app/reminder/new',
+    query: {},
+    asPath: '/app/reminder/new',
+  }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/app/reminder/new',
+}))
+
+jest.mock('@/lib/notification-check', () => ({
+  shouldRedirectToNotificationSettings: jest.fn().mockResolvedValue(false),
+}))
+
+jest.mock('@/lib/calendar', () => ({
+  generateGoogleCalendarUrl: jest.fn(() => 'https://calendar.google.com'),
+  generateICalContent: jest.fn(() => 'BEGIN:VCALENDAR'),
+  downloadICalFile: jest.fn(),
+  isIOS: jest.fn(() => false),
+}))
+
+// グローバルfetchとalertのモック
+global.fetch = jest.fn()
+global.alert = jest.fn()
+
+describe('NewReminderPage', () => {
+  const mockEvents = [
+    {
+      id: 'event-1',
+      name: 'テストイベント1',
+      theme: 'テストテーマ1',
+    },
+    {
+      id: 'event-2',
+      name: 'テストイベント2',
+      theme: null,
+    },
+  ]
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(global.fetch as jest.Mock).mockClear()
+    ;(global.alert as jest.Mock).mockClear()
+  })
+
+  it('ローディング状態を表示する', () => {
+    ;(global.fetch as jest.Mock).mockImplementation(() =>
+      new Promise(() => {}) // 解決しないPromiseでローディング状態を維持
+    )
+
+    render(<NewReminderPage />)
+    expect(screen.getByLabelText('読み込み中')).toBeInTheDocument()
+  })
+
+  it('フォームを表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockEvents,
+    })
+
+    render(<NewReminderPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('リマインダーを新規作成')).toBeInTheDocument()
+    })
+
+    expect(screen.getByPlaceholderText(/エントリー開始、支払期限、集合時間/)).toBeInTheDocument()
+    const datetimeInputs = screen.getAllByDisplayValue('')
+    expect(datetimeInputs.length).toBeGreaterThan(0) // datetime-local input
+  })
+
+  it('イベント一覧を表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockEvents,
+    })
+
+    render(<NewReminderPage />)
+
+    await waitFor(() => {
+      const select = screen.getByRole('combobox')
+      expect(select).toBeInTheDocument()
+      expect(select.querySelector('option[value="event-1"]')).toHaveTextContent('テストイベント1')
+      expect(select.querySelector('option[value="event-2"]')).toHaveTextContent('テストイベント2')
+    })
+  })
+
+  it('フォーム送信でリマインダーを作成する', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockEvents,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 'reminder-1' }),
+      })
+
+    const user = userEvent.setup()
+    render(<NewReminderPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('リマインダーを新規作成')).toBeInTheDocument()
+    })
+
+    const labelInput = screen.getByPlaceholderText(/エントリー開始、支払期限、集合時間/)
+    await user.type(labelInput, 'エントリー締切')
+
+    const datetimeInputs = screen.getAllByDisplayValue('')
+    const datetimeInput = datetimeInputs.find(input => input.getAttribute('type') === 'datetime-local') || datetimeInputs[1]
+    const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000)
+    const datetimeValue = futureDate.toISOString().slice(0, 16)
+    await user.type(datetimeInput, datetimeValue)
+
+    const submitButton = screen.getByRole('button', { name: /作成/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/reminders',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    })
+  })
+
+  it('必須項目が未入力の場合、送信できない', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockEvents,
+    })
+
+    const user = userEvent.setup()
+    render(<NewReminderPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('リマインダーを新規作成')).toBeInTheDocument()
+    })
+
+    const submitButton = screen.getByRole('button', { name: /作成/i })
+    await user.click(submitButton)
+    
+    // HTML5のrequired属性により、フォーム送信が阻止される
+    // fetchが呼ばれていないことを確認（少し待ってから）
+    await new Promise(resolve => setTimeout(resolve, 200))
+    
+    // API呼び出しはイベント取得の1回のみ（作成APIは呼ばれない）
+    const fetchCalls = (global.fetch as jest.Mock).mock.calls
+    const createCalls = fetchCalls.filter(call => call[0] === '/api/reminders' && call[1]?.method === 'POST')
+    expect(createCalls.length).toBe(0)
+  })
+
+  it('作成成功後、カレンダー登録モーダルを表示する', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockEvents,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 'reminder-1' }),
+      })
+
+    const user = userEvent.setup()
+    render(<NewReminderPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('リマインダーを新規作成')).toBeInTheDocument()
+    })
+
+    const labelInput = screen.getByPlaceholderText(/エントリー開始、支払期限、集合時間/)
+    await user.type(labelInput, 'エントリー締切')
+
+    const datetimeInputs = screen.getAllByDisplayValue('')
+    const datetimeInput = datetimeInputs.find(input => input.getAttribute('type') === 'datetime-local') || datetimeInputs[1]
+    const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000)
+    const datetimeValue = futureDate.toISOString().slice(0, 16)
+    await user.type(datetimeInput, datetimeValue)
+
+    const submitButton = screen.getByRole('button', { name: /作成/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('カレンダーに登録')).toBeInTheDocument()
+    }, { timeout: 3000 })
+  })
+
+  it('作成中はボタンが無効化される', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockEvents,
+      })
+      .mockImplementationOnce(() =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({
+              ok: true,
+              json: async () => ({ id: 'reminder-1' }),
+            })
+          }, 100)
+        })
+      )
+
+    const user = userEvent.setup()
+    render(<NewReminderPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('リマインダーを新規作成')).toBeInTheDocument()
+    })
+
+    const labelInput = screen.getByPlaceholderText(/エントリー開始、支払期限、集合時間/)
+    await user.type(labelInput, 'エントリー締切')
+
+    const datetimeInputs = screen.getAllByDisplayValue('')
+    const datetimeInput = datetimeInputs.find(input => input.getAttribute('type') === 'datetime-local') || datetimeInputs[1]
+    const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000)
+    const datetimeValue = futureDate.toISOString().slice(0, 16)
+    await user.type(datetimeInput, datetimeValue)
+
+    const submitButton = screen.getByRole('button', { name: /作成/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('作成中...')).toBeInTheDocument()
+    })
+  })
+
+  it('エラーが発生した場合、エラーメッセージを表示する', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockEvents,
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      })
+
+    const user = userEvent.setup()
+    render(<NewReminderPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('リマインダーを新規作成')).toBeInTheDocument()
+    })
+
+    const labelInput = screen.getByPlaceholderText(/エントリー開始、支払期限、集合時間/)
+    await user.type(labelInput, 'エントリー締切')
+
+    const datetimeInputs = screen.getAllByDisplayValue('')
+    const datetimeInput = datetimeInputs.find(input => input.getAttribute('type') === 'datetime-local') || datetimeInputs[1]
+    const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000)
+    const datetimeValue = futureDate.toISOString().slice(0, 16)
+    await user.type(datetimeInput, datetimeValue)
+
+    const submitButton = screen.getByRole('button', { name: /作成/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(global.alert).toHaveBeenCalledWith('リマインダーの作成に失敗しました')
+    }, { timeout: 3000 })
+  })
+
+  it('リマインダー一覧への戻るリンクを表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockEvents,
+    })
+
+    render(<NewReminderPage />)
+
+    await waitFor(() => {
+      const backLink = screen.getByText(/リマインダー一覧に戻る/)
+      expect(backLink.closest('a')).toHaveAttribute('href', '/app/reminder')
+    })
+  })
+})
+


### PR DESCRIPTION
- app/reminder/page.tsxのテストを実装（14テストケース）
  - ローディング状態、リマインダー一覧表示
  - 今後のリマインダーと過去のリマインダーの分類
  - イベント情報、通知済みバッジ表示
  - ソート機能、新規作成ボタン
  - 削除機能（モーダル表示、削除実行）
  - エラーハンドリング
- app/reminder/new/page.tsxのテストを実装（9テストケース）
  - ローディング状態、フォーム表示
  - イベント一覧表示
  - フォーム送信（作成、バリデーション）
  - カレンダー登録モーダル表示
  - 作成中のボタン無効化、エラーハンドリング
- app/reminder/[id]/edit/page.tsxのテストを実装（9テストケース）
  - ローディング状態、リマインダー情報表示
  - リマインダーが見つからない場合のエラー表示
  - フォーム送信（更新、削除）
  - 削除確認モーダル表示と削除実行
  - 更新中のボタン無効化、エラーハンドリング
- すべてのテストケースが成功（32テストケース）