### PR TITLE
テスト: フォーム送信機能のテストを実装

### DIFF
--- a/src/app/(app)/app/contact/__tests__/page.test.tsx
+++ b/src/app/(app)/app/contact/__tests__/page.test.tsx
@@ -1,0 +1,268 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ContactPage from '../page'
+import { useSession } from 'next-auth/react'
+
+// モック設定
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    back: jest.fn(),
+    pathname: '/app/contact',
+    query: {},
+    asPath: '/app/contact',
+  }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/app/contact',
+}))
+
+const mockUseSession = useSession as jest.MockedFunction<typeof useSession>
+
+// グローバルfetchのモック
+global.fetch = jest.fn()
+
+describe('ContactPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(global.fetch as jest.Mock).mockClear()
+    mockUseSession.mockReturnValue({
+      data: null,
+      status: 'unauthenticated',
+      update: jest.fn(),
+    })
+  })
+
+  it('フォームを表示する', () => {
+    render(<ContactPage />)
+    expect(screen.getByText('お問い合わせフォーム')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/イベント主催について/)).toBeInTheDocument()
+  })
+
+  it('必須項目を表示する', () => {
+    render(<ContactPage />)
+    expect(screen.getByText(/タイトル/)).toBeInTheDocument()
+    expect(screen.getByText(/お名前/)).toBeInTheDocument()
+    expect(screen.getByText(/メールアドレス/)).toBeInTheDocument()
+    expect(screen.getByText(/お問い合わせ内容/)).toBeInTheDocument()
+  })
+
+  it('ログイン中の場合、ログインアカウント情報を表示する', () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          id: 'user-1',
+          name: 'テストユーザー',
+          email: 'test@example.com',
+          role: 'USER',
+          isBanned: false,
+        },
+        expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      },
+      status: 'authenticated',
+      update: jest.fn(),
+    })
+
+    render(<ContactPage />)
+    expect(screen.getByText(/ログイン中のアカウント: test@example.com/)).toBeInTheDocument()
+  })
+
+  it('フォーム送信でお問い合わせを送信する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'contact-1' }),
+    })
+
+    const user = userEvent.setup()
+    render(<ContactPage />)
+
+    const titleInput = screen.getByPlaceholderText(/イベント主催について/)
+    await user.type(titleInput, 'テストタイトル')
+
+    const nameInput = screen.getByPlaceholderText(/お名前またはニックネーム/)
+    await user.type(nameInput, 'テストユーザー')
+
+    const emailInput = screen.getByPlaceholderText(/example@email.com/)
+    await user.type(emailInput, 'test@example.com')
+
+    const contentInput = screen.getByPlaceholderText(/お問い合わせ内容をご記入ください/)
+    await user.type(contentInput, 'テスト内容')
+
+    const submitButton = screen.getByRole('button', { name: /送信する/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/contact',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    })
+  })
+
+  it('送信成功後、成功モーダルを表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'contact-1' }),
+    })
+
+    const user = userEvent.setup()
+    render(<ContactPage />)
+
+    const titleInput = screen.getByPlaceholderText(/イベント主催について/)
+    await user.type(titleInput, 'テストタイトル')
+
+    const nameInput = screen.getByPlaceholderText(/お名前またはニックネーム/)
+    await user.type(nameInput, 'テストユーザー')
+
+    const emailInput = screen.getByPlaceholderText(/example@email.com/)
+    await user.type(emailInput, 'test@example.com')
+
+    const contentInput = screen.getByPlaceholderText(/お問い合わせ内容をご記入ください/)
+    await user.type(contentInput, 'テスト内容')
+
+    const submitButton = screen.getByRole('button', { name: /送信する/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('送信完了')).toBeInTheDocument()
+    }, { timeout: 3000 })
+  })
+
+  it('送信中はボタンが無効化される', async () => {
+    ;(global.fetch as jest.Mock).mockImplementationOnce(() =>
+      new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({
+            ok: true,
+            json: async () => ({ id: 'contact-1' }),
+          })
+        }, 100)
+      })
+    )
+
+    const user = userEvent.setup()
+    render(<ContactPage />)
+
+    const titleInput = screen.getByPlaceholderText(/イベント主催について/)
+    await user.type(titleInput, 'テストタイトル')
+
+    const nameInput = screen.getByPlaceholderText(/お名前またはニックネーム/)
+    await user.type(nameInput, 'テストユーザー')
+
+    const emailInput = screen.getByPlaceholderText(/example@email.com/)
+    await user.type(emailInput, 'test@example.com')
+
+    const contentInput = screen.getByPlaceholderText(/お問い合わせ内容をご記入ください/)
+    await user.type(contentInput, 'テスト内容')
+
+    const submitButton = screen.getByRole('button', { name: /送信する/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('送信中...')).toBeInTheDocument()
+    })
+  })
+
+  it('エラーが発生した場合、エラーモーダルを表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'タイトルは必須です' }),
+    })
+
+    const user = userEvent.setup()
+    render(<ContactPage />)
+
+    // 必須項目を入力せずに送信を試みる（HTML5のrequired属性により送信できない）
+    // 代わりに、必須項目を入力してから送信
+    const titleInput = screen.getByPlaceholderText(/イベント主催について/)
+    await user.type(titleInput, 'テストタイトル')
+
+    const nameInput = screen.getByPlaceholderText(/お名前またはニックネーム/)
+    await user.type(nameInput, 'テストユーザー')
+
+    const emailInput = screen.getByPlaceholderText(/example@email.com/)
+    await user.type(emailInput, 'test@example.com')
+
+    const contentInput = screen.getByPlaceholderText(/お問い合わせ内容をご記入ください/)
+    await user.type(contentInput, 'テスト内容')
+
+    const submitButton = screen.getByRole('button', { name: /送信する/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('送信エラー')).toBeInTheDocument()
+    }, { timeout: 3000 })
+  })
+
+  it('ログイン中の場合、マイページへの戻るリンクを表示する', () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          id: 'user-1',
+          name: 'テストユーザー',
+          email: 'test@example.com',
+          role: 'USER',
+          isBanned: false,
+        },
+        expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      },
+      status: 'authenticated',
+      update: jest.fn(),
+    })
+
+    render(<ContactPage />)
+    const backLink = screen.getByText(/マイページへ戻る/)
+    expect(backLink.closest('a')).toHaveAttribute('href', '/app/mypage')
+  })
+
+  it('未ログインの場合、トップページへの戻るリンクを表示する', () => {
+    mockUseSession.mockReturnValue({
+      data: null,
+      status: 'unauthenticated',
+      update: jest.fn(),
+    })
+
+    render(<ContactPage />)
+    const backLink = screen.getByText(/トップページへ戻る/)
+    expect(backLink.closest('a')).toHaveAttribute('href', '/')
+  })
+
+  it('ログイン中の場合、キャンセルボタンがマイページへのリンクになっている', () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          id: 'user-1',
+          name: 'テストユーザー',
+          email: 'test@example.com',
+          role: 'USER',
+          isBanned: false,
+        },
+        expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      },
+      status: 'authenticated',
+      update: jest.fn(),
+    })
+
+    render(<ContactPage />)
+    const cancelButton = screen.getByRole('link', { name: /キャンセル/i })
+    expect(cancelButton).toHaveAttribute('href', '/app/mypage')
+  })
+
+  it('未ログインの場合、キャンセルボタンがトップページへのリンクになっている', () => {
+    mockUseSession.mockReturnValue({
+      data: null,
+      status: 'unauthenticated',
+      update: jest.fn(),
+    })
+
+    render(<ContactPage />)
+    const cancelButton = screen.getByRole('link', { name: /キャンセル/i })
+    expect(cancelButton).toHaveAttribute('href', '/')
+  })
+})
+

--- a/src/app/(app)/app/event-submission/__tests__/page.test.tsx
+++ b/src/app/(app)/app/event-submission/__tests__/page.test.tsx
@@ -1,0 +1,204 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import EventSubmissionPage from '../page'
+
+// モック設定
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    back: jest.fn(),
+    pathname: '/app/event-submission',
+    query: {},
+    asPath: '/app/event-submission',
+  }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/app/event-submission',
+}))
+
+// グローバルfetchのモック
+global.fetch = jest.fn()
+
+describe('EventSubmissionPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(global.fetch as jest.Mock).mockClear()
+  })
+
+  it('フォームを表示する', () => {
+    render(<EventSubmissionPage />)
+    expect(screen.getByText('イベント掲載依頼フォーム')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/痛車ヘブン夏/)).toBeInTheDocument()
+  })
+
+  it('必須項目を表示する', () => {
+    render(<EventSubmissionPage />)
+    expect(screen.getByText(/イベント名/)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/痛車ヘブン夏/)).toHaveAttribute('required')
+  })
+
+  it('任意項目を表示する', () => {
+    render(<EventSubmissionPage />)
+    expect(screen.getByText(/イベント情報URL/)).toBeInTheDocument()
+    expect(screen.getByText(/開催日/)).toBeInTheDocument()
+  })
+
+  it('フォーム送信でイベント掲載依頼を送信する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'submission-1' }),
+    })
+
+    const user = userEvent.setup()
+    render(<EventSubmissionPage />)
+
+    const nameInput = screen.getByPlaceholderText(/痛車ヘブン夏/)
+    await user.type(nameInput, 'テストイベント')
+
+    const submitButton = screen.getByRole('button', { name: /送信/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/event-submissions',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    })
+  })
+
+  it('送信成功後、成功モーダルを表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'submission-1' }),
+    })
+
+    const user = userEvent.setup()
+    render(<EventSubmissionPage />)
+
+    const nameInput = screen.getByPlaceholderText(/痛車ヘブン夏/)
+    await user.type(nameInput, 'テストイベント')
+
+    const submitButton = screen.getByRole('button', { name: /送信/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('送信完了')).toBeInTheDocument()
+    }, { timeout: 3000 })
+  })
+
+  it('送信成功後、フォームをクリアする', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'submission-1' }),
+    })
+
+    const user = userEvent.setup()
+    render(<EventSubmissionPage />)
+
+    const nameInput = screen.getByPlaceholderText(/痛車ヘブン夏/)
+    await user.type(nameInput, 'テストイベント')
+
+    const submitButton = screen.getByRole('button', { name: /送信/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(nameInput).toHaveValue('')
+    }, { timeout: 3000 })
+  })
+
+  it('送信中はボタンが無効化される', async () => {
+    ;(global.fetch as jest.Mock).mockImplementationOnce(() =>
+      new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({
+            ok: true,
+            json: async () => ({ id: 'submission-1' }),
+          })
+        }, 100)
+      })
+    )
+
+    const user = userEvent.setup()
+    render(<EventSubmissionPage />)
+
+    const nameInput = screen.getByPlaceholderText(/痛車ヘブン夏/)
+    await user.type(nameInput, 'テストイベント')
+
+    const submitButton = screen.getByRole('button', { name: /送信/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('送信中...')).toBeInTheDocument()
+    })
+  })
+
+  it('エラーが発生した場合、エラーモーダルを表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'イベント名は必須です' }),
+    })
+
+    const user = userEvent.setup()
+    render(<EventSubmissionPage />)
+
+    // イベント名を入力せずに送信
+    const submitButton = screen.getByRole('button', { name: /送信/i })
+    // HTML5のrequired属性により送信できないため、直接フォームを送信
+    const form = submitButton.closest('form')
+    if (form) {
+      const submitEvent = new Event('submit', { bubbles: true, cancelable: true })
+      form.dispatchEvent(submitEvent)
+    }
+
+    // または、イベント名を入力してから送信
+    const nameInput = screen.getByPlaceholderText(/痛車ヘブン夏/)
+    await user.type(nameInput, 'テストイベント')
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('送信失敗')).toBeInTheDocument()
+    }, { timeout: 3000 })
+  })
+
+  it('エラー時は入力内容を保持する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'サーバーエラー' }),
+    })
+
+    const user = userEvent.setup()
+    render(<EventSubmissionPage />)
+
+    const nameInput = screen.getByPlaceholderText(/痛車ヘブン夏/)
+    await user.type(nameInput, 'テストイベント')
+
+    const submitButton = screen.getByRole('button', { name: /送信/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('送信失敗')).toBeInTheDocument()
+    }, { timeout: 3000 })
+
+    // エラー後も入力内容が保持されている
+    expect(nameInput).toHaveValue('テストイベント')
+  })
+
+  it('マイページへの戻るリンクを表示する', () => {
+    render(<EventSubmissionPage />)
+    const backLink = screen.getByText(/マイページへ戻る/)
+    expect(backLink.closest('a')).toHaveAttribute('href', '/app/mypage')
+  })
+
+  it('キャンセルボタンがマイページへのリンクになっている', () => {
+    render(<EventSubmissionPage />)
+    const cancelButton = screen.getByRole('link', { name: /キャンセル/i })
+    expect(cancelButton).toHaveAttribute('href', '/app/mypage')
+  })
+})
+


### PR DESCRIPTION
- app/event-submission/page.tsxのテストを実装（10テストケース）
  - フォーム表示、必須項目・任意項目
  - フォーム送信、成功モーダル表示
  - 送信後のフォームクリア
  - 送信中のボタン無効化、エラーモーダル表示
  - エラー時の入力内容保持
  - マイページへの戻るリンク、キャンセルボタン
- app/contact/page.tsxのテストを実装（12テストケース）
  - フォーム表示、必須項目
  - ログイン中のアカウント情報表示
  - フォーム送信、成功モーダル表示
  - 送信中のボタン無効化、エラーモーダル表示
  - ログイン状態による戻るリンク・キャンセルボタンの切り替え
- すべてのテストケースが成功（22テストケース）