### PR TITLE
テスト: イベント一覧ページとイベント詳細ページのテストを実装

### DIFF
--- a/src/app/(app)/events/[slug]/__tests__/page.test.tsx
+++ b/src/app/(app)/events/[slug]/__tests__/page.test.tsx
@@ -1,0 +1,253 @@
+import { render, screen } from '@testing-library/react'
+import EventDetailPage from '../page'
+import { prisma } from '@/lib/prisma'
+
+// モック設定
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    event: {
+      findUnique: jest.fn(),
+    },
+  },
+}))
+
+const mockNotFound = jest.fn()
+jest.mock('next/navigation', () => ({
+  notFound: () => {
+    mockNotFound()
+    throw new Error('notFound')
+  },
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    back: jest.fn(),
+    pathname: '/events/event-1',
+    query: {},
+    asPath: '/events/event-1',
+  }),
+}))
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: null,
+    status: 'unauthenticated',
+    update: jest.fn(),
+  }),
+}))
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ src, alt, ...props }: { src: string; alt: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} {...props} />
+  ),
+}))
+
+const mockPrisma = prisma as unknown as {
+  event: {
+    findUnique: jest.Mock
+  }
+}
+
+describe('EventDetailPage', () => {
+  const mockEvent = {
+    id: 'event-1',
+    name: 'テストイベント',
+    description: 'テストイベントの説明です。',
+    event_date: new Date('2024-12-31T10:00:00Z'),
+    event_end_date: null,
+    is_multi_day: false,
+    approval_status: 'APPROVED',
+    prefecture: '東京都',
+    city: '渋谷区',
+    street_address: 'テスト1-2-3',
+    venue_name: 'テスト会場',
+    keywords: ['痛車', 'イベント'],
+    official_urls: ['https://example.com/event1'],
+    image_url: 'https://example.com/image1.jpg',
+    entry_selection_method: 'FIRST_COME',
+    entries: [
+      {
+        entry_number: 1,
+        entry_start_at: new Date('2024-11-01T00:00:00Z'),
+        entry_start_public_at: null,
+        entry_deadline_at: new Date('2024-12-01T23:59:59Z'),
+        payment_due_type: 'FIXED',
+        payment_due_at: new Date('2024-12-15T23:59:59Z'),
+        payment_due_days_after_entry: null,
+        payment_due_public_at: null,
+      },
+    ],
+    tags: [
+      { tag: { name: 'タグ1' } },
+      { tag: { name: 'タグ2' } },
+    ],
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('イベント詳細を表示する', async () => {
+    mockPrisma.event.findUnique.mockResolvedValue(mockEvent as never)
+
+    const params = Promise.resolve({ slug: 'event-1' })
+    const page = await EventDetailPage({ params })
+    render(page)
+
+    expect(screen.getByText('テストイベント')).toBeInTheDocument()
+    expect(screen.getAllByText('テストイベントの説明です。').length).toBeGreaterThan(0)
+  })
+
+  it('イベントが見つからない場合、notFoundを呼び出す', async () => {
+    mockPrisma.event.findUnique.mockResolvedValue(null)
+
+    const params = Promise.resolve({ slug: 'non-existent' })
+    
+    await expect(EventDetailPage({ params })).rejects.toThrow('notFound')
+    expect(mockNotFound).toHaveBeenCalled()
+  })
+
+  it('イベント名を表示する', async () => {
+    mockPrisma.event.findUnique.mockResolvedValue(mockEvent as never)
+
+    const params = Promise.resolve({ slug: 'event-1' })
+    const page = await EventDetailPage({ params })
+    render(page)
+
+    expect(screen.getByText('テストイベント')).toBeInTheDocument()
+  })
+
+  it('イベント説明を表示する', async () => {
+    mockPrisma.event.findUnique.mockResolvedValue(mockEvent as never)
+
+    const params = Promise.resolve({ slug: 'event-1' })
+    const page = await EventDetailPage({ params })
+    render(page)
+
+    expect(screen.getAllByText('テストイベントの説明です。').length).toBeGreaterThan(0)
+  })
+
+  it('イベント画像を表示する', async () => {
+    mockPrisma.event.findUnique.mockResolvedValue(mockEvent as never)
+
+    const params = Promise.resolve({ slug: 'event-1' })
+    const page = await EventDetailPage({ params })
+    render(page)
+
+    const image = screen.getByAltText('テストイベント')
+    expect(image).toHaveAttribute('src', 'https://example.com/image1.jpg')
+  })
+
+  it('キーワードを表示する', async () => {
+    mockPrisma.event.findUnique.mockResolvedValue(mockEvent as never)
+
+    const params = Promise.resolve({ slug: 'event-1' })
+    const page = await EventDetailPage({ params })
+    render(page)
+
+    expect(screen.getByText('痛車')).toBeInTheDocument()
+    expect(screen.getByText('イベント')).toBeInTheDocument()
+  })
+
+  it('タグを表示する', async () => {
+    mockPrisma.event.findUnique.mockResolvedValue(mockEvent as never)
+
+    const params = Promise.resolve({ slug: 'event-1' })
+    const page = await EventDetailPage({ params })
+    render(page)
+
+    expect(screen.getByText('タグ1')).toBeInTheDocument()
+    expect(screen.getByText('タグ2')).toBeInTheDocument()
+  })
+
+  it('開催情報を表示する', async () => {
+    mockPrisma.event.findUnique.mockResolvedValue(mockEvent as never)
+
+    const params = Promise.resolve({ slug: 'event-1' })
+    const page = await EventDetailPage({ params })
+    render(page)
+
+    expect(screen.getByText(/開催情報/)).toBeInTheDocument()
+    expect(screen.getAllByText(/東京都/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/テスト会場/).length).toBeGreaterThan(0)
+  })
+
+  it('エントリー情報を表示する', async () => {
+    mockPrisma.event.findUnique.mockResolvedValue(mockEvent as never)
+
+    const params = Promise.resolve({ slug: 'event-1' })
+    const page = await EventDetailPage({ params })
+    render(page)
+
+    expect(screen.getByText(/エントリー/)).toBeInTheDocument()
+    expect(screen.getByText(/開始/)).toBeInTheDocument()
+    expect(screen.getByText(/締切/)).toBeInTheDocument()
+  })
+
+  it('公式サイトリンクを表示する', async () => {
+    mockPrisma.event.findUnique.mockResolvedValue(mockEvent as never)
+
+    const params = Promise.resolve({ slug: 'event-1' })
+    const page = await EventDetailPage({ params })
+    render(page)
+
+    const link = screen.getByText('https://example.com/event1')
+    expect(link.closest('a')).toHaveAttribute('href', 'https://example.com/event1')
+    expect(link.closest('a')).toHaveAttribute('target', '_blank')
+  })
+
+  it('複数日のイベントの場合、終了日を表示する', async () => {
+    const multiDayEvent = {
+      ...mockEvent,
+      event_end_date: new Date('2025-01-01T18:00:00Z'),
+      is_multi_day: true,
+    }
+
+    mockPrisma.event.findUnique.mockResolvedValue(multiDayEvent as never)
+
+    const params = Promise.resolve({ slug: 'event-1' })
+    const page = await EventDetailPage({ params })
+    render(page)
+
+    expect(screen.getByText(/〜/)).toBeInTheDocument()
+  })
+
+  it('イベント一覧への戻るリンクを表示する', async () => {
+    mockPrisma.event.findUnique.mockResolvedValue(mockEvent as never)
+
+    const params = Promise.resolve({ slug: 'event-1' })
+    const page = await EventDetailPage({ params })
+    render(page)
+
+    const backLink = screen.getByText(/イベント一覧に戻る/)
+    expect(backLink.closest('a')).toHaveAttribute('href', '/events')
+  })
+
+  it('エントリー情報がない場合、未定を表示する', async () => {
+    const eventWithoutEntries = {
+      ...mockEvent,
+      entries: [],
+    }
+
+    mockPrisma.event.findUnique.mockResolvedValue(eventWithoutEntries as never)
+
+    const params = Promise.resolve({ slug: 'event-1' })
+    const page = await EventDetailPage({ params })
+    render(page)
+
+    expect(screen.getByText(/未定/)).toBeInTheDocument()
+  })
+
+  it('支払期限を表示する', async () => {
+    mockPrisma.event.findUnique.mockResolvedValue(mockEvent as never)
+
+    const params = Promise.resolve({ slug: 'event-1' })
+    const page = await EventDetailPage({ params })
+    render(page)
+
+    expect(screen.getByText(/支払期限/)).toBeInTheDocument()
+  })
+})
+

--- a/src/app/(app)/events/__tests__/page.test.tsx
+++ b/src/app/(app)/events/__tests__/page.test.tsx
@@ -1,0 +1,325 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import EventsPage from '../page'
+
+// モック設定
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    back: jest.fn(),
+    pathname: '/events',
+    query: {},
+    asPath: '/events',
+  }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/events',
+}))
+
+// グローバルfetchのモック
+global.fetch = jest.fn()
+
+describe('EventsPage', () => {
+  const mockEvents = [
+    {
+      id: 'event-1',
+      name: 'テストイベント1',
+      description: 'テスト説明1',
+      event_date: '2024-12-31T10:00:00Z',
+      event_end_date: null,
+      is_multi_day: false,
+      official_urls: ['https://example.com/event1'],
+      keywords: ['痛車', 'イベント'],
+      image_url: 'https://example.com/image1.jpg',
+      approval_status: 'APPROVED',
+      entries: [
+        {
+          entry_number: 1,
+          entry_start_at: '2024-11-01T00:00:00Z',
+          entry_start_public_at: null,
+          entry_deadline_at: '2024-12-01T23:59:59Z',
+          payment_due_at: '2024-12-15T23:59:59Z',
+          payment_due_public_at: null,
+        },
+      ],
+      tags: [
+        { tag: { name: 'タグ1' } },
+      ],
+    },
+    {
+      id: 'event-2',
+      name: 'テストイベント2',
+      description: 'テスト説明2',
+      event_date: '2025-01-15T10:00:00Z',
+      event_end_date: '2025-01-16T18:00:00Z',
+      is_multi_day: true,
+      official_urls: [],
+      keywords: null,
+      image_url: null,
+      approval_status: 'APPROVED',
+      entries: [],
+      tags: [],
+    },
+  ]
+
+  const mockPagination = {
+    currentPage: 1,
+    totalPages: 1,
+    totalCount: 2,
+    limit: 10,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(global.fetch as jest.Mock).mockClear()
+  })
+
+  it('ローディング状態を表示する', () => {
+    ;(global.fetch as jest.Mock).mockImplementation(() =>
+      new Promise(() => {}) // 解決しないPromiseでローディング状態を維持
+    )
+
+    render(<EventsPage />)
+    expect(screen.getByLabelText('読み込み中')).toBeInTheDocument()
+  })
+
+  it('イベント一覧を表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        events: mockEvents,
+        pagination: mockPagination,
+      }),
+    })
+
+    render(<EventsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('テストイベント1')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('テストイベント2')).toBeInTheDocument()
+  })
+
+  it('イベントが空の場合、空のメッセージを表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        events: [],
+        pagination: null,
+      }),
+    })
+
+    render(<EventsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('イベントが登録されていません。')).toBeInTheDocument()
+    })
+  })
+
+  it('検索フォームを表示する', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        events: mockEvents,
+        pagination: mockPagination,
+      }),
+    })
+
+    render(<EventsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('検索')).toBeInTheDocument()
+    })
+
+    expect(screen.getByLabelText('表示順')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '検索' })).toBeInTheDocument()
+  })
+
+  it('検索を実行すると、検索クエリでAPIを呼び出す', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          events: mockEvents,
+          pagination: mockPagination,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          events: mockEvents,
+          pagination: mockPagination,
+        }),
+      })
+
+    const user = userEvent.setup()
+    render(<EventsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('検索')).toBeInTheDocument()
+    })
+
+    const searchInput = screen.getByLabelText('検索')
+    await user.type(searchInput, 'テスト')
+    await user.click(screen.getByRole('button', { name: '検索' }))
+
+    await waitFor(() => {
+      const calls = (global.fetch as jest.Mock).mock.calls
+      const lastCall = calls[calls.length - 1]
+      expect(lastCall[0]).toMatch(/search=.*%E3%83%86%E3%82%B9%E3%83%88/)
+    })
+  })
+
+  it('ソート順を変更すると、ソート順でAPIを呼び出す', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          events: mockEvents,
+          pagination: mockPagination,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          events: mockEvents,
+          pagination: mockPagination,
+        }),
+      })
+
+    const user = userEvent.setup()
+    render(<EventsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('表示順')).toBeInTheDocument()
+    })
+
+    const sortSelect = screen.getByLabelText('表示順')
+    await user.selectOptions(sortSelect, 'desc')
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('sortOrder=desc')
+      )
+    })
+  })
+
+  it('ページネーションを表示する（複数ページの場合）', async () => {
+    const multiPagePagination = {
+      currentPage: 1,
+      totalPages: 3,
+      totalCount: 25,
+      limit: 10,
+    }
+
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        events: mockEvents,
+        pagination: multiPagePagination,
+      }),
+    })
+
+    render(<EventsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('1')).toBeInTheDocument()
+    })
+  })
+
+  it('ページネーションを表示しない（1ページのみの場合）', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        events: mockEvents,
+        pagination: mockPagination,
+      }),
+    })
+
+    render(<EventsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('テストイベント1')).toBeInTheDocument()
+    })
+
+    // ページネーションは表示されない
+    expect(screen.queryByText('1')).not.toBeInTheDocument()
+  })
+
+  it('検索結果が空の場合、検索結果なしメッセージを表示する', async () => {
+    ;(global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          events: mockEvents,
+          pagination: mockPagination,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          events: [],
+          pagination: {
+            currentPage: 1,
+            totalPages: 0,
+            totalCount: 0,
+            limit: 10,
+          },
+        }),
+      })
+
+    const user = userEvent.setup()
+    render(<EventsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('検索')).toBeInTheDocument()
+    })
+
+    const searchInput = screen.getByLabelText('検索')
+    await user.clear(searchInput)
+    await user.type(searchInput, '存在しないイベント')
+    await user.click(screen.getByRole('button', { name: '検索' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/検索条件に一致するイベントが見つかりませんでした/)
+      ).toBeInTheDocument()
+    }, { timeout: 3000 })
+  })
+
+  it('エラーが発生した場合、エラーログを出力する', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+    ;(global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'))
+
+    render(<EventsPage />)
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to fetch events:',
+        expect.any(Error)
+      )
+    })
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('イベントカードがリンクになっている', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        events: mockEvents,
+        pagination: mockPagination,
+      }),
+    })
+
+    render(<EventsPage />)
+
+    await waitFor(() => {
+      const eventCard = screen.getByText('テストイベント1').closest('a')
+      expect(eventCard).toHaveAttribute('href', '/events/event-1')
+    })
+  })
+})
+


### PR DESCRIPTION
- app/events/page.tsxのテストを実装（11テストケース）
  - ローディング状態、一覧表示、空状態
  - 検索、ソート、ページネーション
  - エラーハンドリング
- app/events/[slug]/page.tsxのテストを実装（14テストケース）
  - イベント詳細表示、画像、キーワード、タグ
  - 開催情報、エントリー情報、公式サイトリンク
  - 複数日イベント、notFound処理
- 合計25テストケース、すべて成功