### PR TITLE
fix: sp版ヘッダーのハンバーガーメニューを左側に移動

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -258,6 +258,11 @@ function MobileHeader({
       className={`fixed top-0 left-0 right-0 z-30 flex h-14 items-center justify-between border-b border-zinc-200 bg-white/90 px-4 backdrop-blur transition-transform duration-300 ease-in-out sm:hidden ${isVisible ? "translate-y-0" : "-translate-y-full"
         }`}
     >
+      <MenuController
+        variant="open"
+        onClick={onMenuClick}
+        className="h-10 w-10 border border-zinc-200 bg-white shadow-sm"
+      />
       <Link href="/app/mypage" className="flex items-center">
         <Image
           src="/images/main_logo.png"
@@ -268,11 +273,6 @@ function MobileHeader({
           priority
         />
       </Link>
-      <MenuController
-        variant="open"
-        onClick={onMenuClick}
-        className="h-10 w-10 border border-zinc-200 bg-white shadow-sm"
-      />
     </header>
   );
 }


### PR DESCRIPTION
## 概要
Issue #20に対応し、sp版ヘッダーのハンバーガーメニューの位置を右から左に変更しました。

## 変更内容
- `MobileHeader`コンポーネントでハンバーガーメニューとロゴの順序を入れ替え
- ハンバーガーメニューを左側、ロゴを右側に配置

## 関連Issue
Closes #20

## 動作確認
- [x] スマートフォン表示でハンバーガーメニューが左側に表示されることを確認
- [x] ハンバーガーメニューのクリック動作が正常であることを確認
- [x] ロゴの表示位置が適切であることを確認