### PR TITLE
feat: プロフィール編集画面のリダイレクトタイムアウト表示を改善

### DIFF
--- a/src/app/(app)/app/profile/edit/page.tsx
+++ b/src/app/(app)/app/profile/edit/page.tsx
@@ -6,6 +6,10 @@ import { useSession } from "next-auth/react";
 import { Button } from "@/components/button";
 import { LoadingSpinner } from "@/components/loading-spinner";
 
+// マイページへのリダイレクトタイムアウト時間（ミリ秒）
+const REDIRECT_TIMEOUT_MS = 2000;
+const REDIRECT_TIMEOUT_SECONDS = REDIRECT_TIMEOUT_MS / 1000;
+
 export default function ProfileEditPage() {
     const router = useRouter();
     const { data: session, status, update } = useSession();
@@ -61,11 +65,11 @@ export default function ProfileEditPage() {
             // セッションを更新
             await update();
             setSuccess(true);
-            
-            // 2秒後にマイページに戻る
+
+            // タイムアウト後にマイページに戻る
             setTimeout(() => {
                 router.push("/app/mypage");
-            }, 2000);
+            }, REDIRECT_TIMEOUT_MS);
         } catch (error) {
             console.error("Failed to save display name:", error);
             setError(
@@ -87,85 +91,85 @@ export default function ProfileEditPage() {
                 ) : (
                     <>
                         <header>
-                    <h1 className="text-xl font-semibold tracking-tight sm:text-2xl">
-                        基本情報の変更
-                    </h1>
-                    <p className="mt-2 text-xs text-zinc-600 sm:text-sm">
-                        プロフィールなどの情報を表示し、編集できます。
-                    </p>
-                </header>
-
-                <div className="rounded-2xl border border-zinc-200 bg-white p-4 sm:p-5">
-                    <form onSubmit={handleSubmit} className="space-y-6">
-                        {error && (
-                            <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
-                                {error}
-                            </div>
-                        )}
-
-                        {success && (
-                            <div className="rounded-md bg-emerald-50 p-3 text-sm text-emerald-700">
-                                表示名を保存しました。マイページに戻ります...
-                            </div>
-                        )}
-
-                        <div>
-                            <label
-                                htmlFor="displayName"
-                                className="block text-sm font-medium text-zinc-700 mb-2"
-                            >
-                                表示名（任意、全角50文字以内）
-                            </label>
-                            <input
-                                id="displayName"
-                                type="text"
-                                value={displayName}
-                                onChange={(e) => {
-                                    const value = e.target.value;
-                                    // 全角50文字以内に制限
-                                    const charCount = Array.from(value).length;
-                                    if (charCount <= 50) {
-                                        setDisplayName(value);
-                                    }
-                                }}
-                                placeholder="例: 痛車太郎"
-                                className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-900 focus:outline-none focus:ring-1 focus:ring-zinc-900"
-                                maxLength={50}
-                            />
-                            <p className="mt-1 text-xs text-zinc-500">
-                                {Array.from(displayName).length} / 50文字
+                            <h1 className="text-xl font-semibold tracking-tight sm:text-2xl">
+                                基本情報の変更
+                            </h1>
+                            <p className="mt-2 text-xs text-zinc-600 sm:text-sm">
+                                プロフィールなどの情報を表示し、編集できます。
                             </p>
-                            <p className="mt-2 text-xs text-zinc-600">
-                                団体チャットなどで表示される表示名（ニックネーム）を設定できます。
-                                実名を公開したくない場合でも、この表示名で参加できます。
-                            </p>
-                            <p className="mt-1 text-xs text-zinc-600">
-                                未設定の場合はログインしたアカウントの名前を使用します。
-                            </p>
+                        </header>
+
+                        <div className="rounded-2xl border border-zinc-200 bg-white p-4 sm:p-5">
+                            <form onSubmit={handleSubmit} className="space-y-6">
+                                {error && (
+                                    <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+                                        {error}
+                                    </div>
+                                )}
+
+                                {success && (
+                                    <div className="rounded-md bg-emerald-50 p-3 text-sm text-emerald-700">
+                                        表示名を保存しました。{REDIRECT_TIMEOUT_SECONDS}秒後にマイページに戻ります...
+                                    </div>
+                                )}
+
+                                <div>
+                                    <label
+                                        htmlFor="displayName"
+                                        className="block text-sm font-medium text-zinc-700 mb-2"
+                                    >
+                                        表示名（任意、全角50文字以内）
+                                    </label>
+                                    <input
+                                        id="displayName"
+                                        type="text"
+                                        value={displayName}
+                                        onChange={(e) => {
+                                            const value = e.target.value;
+                                            // 全角50文字以内に制限
+                                            const charCount = Array.from(value).length;
+                                            if (charCount <= 50) {
+                                                setDisplayName(value);
+                                            }
+                                        }}
+                                        placeholder="例: 痛車太郎"
+                                        className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-900 focus:outline-none focus:ring-1 focus:ring-zinc-900"
+                                        maxLength={50}
+                                    />
+                                    <p className="mt-1 text-xs text-zinc-500">
+                                        {Array.from(displayName).length} / 50文字
+                                    </p>
+                                    <p className="mt-2 text-xs text-zinc-600">
+                                        団体チャットなどで表示される表示名（ニックネーム）を設定できます。
+                                        実名を公開したくない場合でも、この表示名で参加できます。
+                                    </p>
+                                    <p className="mt-1 text-xs text-zinc-600">
+                                        未設定の場合はログインしたアカウントの名前を使用します。
+                                    </p>
+                                </div>
+
+                                <div className="flex gap-3">
+                                    <Button
+                                        as="link"
+                                        href="/app/mypage"
+                                        variant="secondary"
+                                        size="md"
+                                        rounded="md"
+                                    >
+                                        キャンセル
+                                    </Button>
+                                    <Button
+                                        type="submit"
+                                        variant="primary"
+                                        size="md"
+                                        rounded="md"
+                                        disabled={saving || !displayName.trim()}
+                                    >
+                                        {saving ? "保存中..." : "保存"}
+                                    </Button>
+                                </div>
+                            </form>
                         </div>
-
-                        <div className="flex gap-3">
-                            <Button
-                                as="link"
-                                href="/app/mypage"
-                                variant="secondary"
-                                size="md"
-                                rounded="md"
-                            >
-                                キャンセル
-                            </Button>
-                            <Button
-                                type="submit"
-                                variant="primary"
-                                size="md"
-                                rounded="md"
-                                disabled={saving || !displayName.trim()}
-                            >
-                                {saving ? "保存中..." : "保存"}
-                            </Button>
-                        </div>
-                    </form>
-                </div>
                     </>
                 )}
             </section>


### PR DESCRIPTION
## 概要
プロフィール編集画面でユーザー表示名を更新した際のリダイレクトタイムアウト表示を改善しました。

## 変更内容
- リダイレクトタイムアウト時間を定数 `REDIRECT_TIMEOUT_MS` で管理
- 成功メッセージにタイムアウト秒数を表示（例：「表示名を保存しました。2秒後にマイページに戻ります...」）
- タイムアウト時間を変更する際は、定数を変更するだけでメッセージも自動的に連動

## 変更ファイル
- `src/app/(app)/app/profile/edit/page.tsx`

## 技術的な詳細
- `REDIRECT_TIMEOUT_MS`（2000ミリ秒）を定数として定義
- `REDIRECT_TIMEOUT_SECONDS` を計算用の定数として定義
- `setTimeout` とメッセージ表示の両方で同じ定数を使用することで、一貫性を確保

## 動作確認
- [x] プロフィール編集画面で表示名を更新
- [x] 成功メッセージに「2秒後にマイページに戻ります...」と表示されることを確認
- [x] 2秒後にマイページに自動リダイレクトされることを確認

## 関連Issue
（該当する場合はIssue番号を記載）