### PR TITLE
主催者フィールドを廃止し、イベント登録者フィールドに移行

### DIFF
--- a/prisma/migrations/20260113201443_remove_organizer_fields/migration.sql
+++ b/prisma/migrations/20260113201443_remove_organizer_fields/migration.sql
@@ -1,0 +1,23 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `organizer_email` on the `events` table. All the data in the column will be lost.
+  - You are about to drop the column `organizer_user_id` on the `events` table. All the data in the column will be lost.
+  - You are about to drop the foreign key `events_organizer_user_id_fkey` on the `events` table. All the data in the column will be lost.
+
+*/
+
+-- 既存データの移行: organizer_user_idをcreated_by_user_idにコピー
+-- organizer_user_idが設定されていて、created_by_user_idがNULLの場合のみ移行
+UPDATE `events` 
+SET `created_by_user_id` = `organizer_user_id` 
+WHERE `organizer_user_id` IS NOT NULL 
+  AND `created_by_user_id` IS NULL;
+
+-- DropForeignKey
+ALTER TABLE `events` DROP FOREIGN KEY `events_organizer_user_id_fkey`;
+
+-- AlterTable
+ALTER TABLE `events` DROP COLUMN `organizer_email`,
+    DROP COLUMN `organizer_user_id`;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,10 +45,7 @@ model User {
   group_message_reads  GroupMessageRead[] @relation("GroupMessageReadUser") // 団体メッセージの既読情報
   event_follows        EventFollow[] // フォローしているイベント
 
-  // 【修正】主催しているイベントのリスト
-  events_organized Event[] @relation("EventOrganizer")
-
-  // 作成したイベントのリスト（最初にイベントを作成したアカウント）
+  // 登録したイベントのリスト（イベントを登録したアカウント）
   events_created Event[] @relation("EventCreator")
 
   // 情報提供フォーム
@@ -158,16 +155,9 @@ model Event {
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
 
-  // リレーション
-  organizer_user    User?   @relation("EventOrganizer", fields: [organizer_user_id], references: [id])
-  organizer_user_id String? @db.VarChar(36)
-
-  // イベント作成者（最初にイベントを作成したアカウント、変更不可）
+  // イベント登録者（イベントを登録したアカウント、変更不可、フロントには表示しない）
   created_by_user    User?   @relation("EventCreator", fields: [created_by_user_id], references: [id])
   created_by_user_id String? @db.VarChar(36)
-
-  // 主催者メールアドレス（必須、フロントには出ない）
-  organizer_email String @db.VarChar(255)
 
   participants UserEvent[]
   groups       Group[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -140,7 +140,6 @@ function generateEvents(count: number) {
       venue_name: Math.random() > 0.3 ? venueName : null,
       official_urls: [],
       approval_status: randomElement(["DRAFT", "PENDING", "APPROVED", "REJECTED"]),
-      organizer_email: `organizer${i}@example.com`,
     });
   }
 
@@ -164,8 +163,8 @@ async function main() {
 
   console.info("⏳ 100個のサンプルイベントを生成中...");
 
-  // 主催者ユーザーを取得または作成
-  const organizerUser = await prisma.user.upsert({
+  // イベント登録者ユーザーを取得または作成
+  const createdByUser = await prisma.user.upsert({
     where: { email: "organizer@itasha-portal.com" },
     update: {},
     create: {
@@ -185,7 +184,7 @@ async function main() {
       await prisma.event.create({
         data: {
           ...eventData,
-          organizer_user_id: organizerUser.id,
+          created_by_user_id: createdByUser.id,
         },
       });
       createdCount++;

--- a/src/app/(app)/admin/events/new/page.tsx
+++ b/src/app/(app)/admin/events/new/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useSession } from "next-auth/react";
 import Link from "next/link";
 import ConfirmModal from "@/components/confirm-modal";
 import EventForm, { EventFormData } from "@/components/event-form";
@@ -12,7 +11,6 @@ import { LoadingSpinner } from "@/components/loading-spinner";
 function AdminNewEventPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { data: session } = useSession();
 
   useEffect(() => {
     document.title = "いたなび管理画面 | 新規イベント作成";
@@ -32,7 +30,6 @@ function AdminNewEventPageContent() {
     city: "",
     street_address: "",
     venue_name: "",
-    organizer_email: session?.user?.email || "",
     image_url: "",
     official_urls: [""],
     entry_selection_method: "FIRST_COME",
@@ -123,17 +120,11 @@ function AdminNewEventPageContent() {
     setSaving(true);
 
     try {
-      // イベント作成時は、ログインユーザーの情報を自動設定
-      // organizer_emailが空の場合は、ログインユーザーのメールアドレスを使用
-      const organizerEmail = formData.organizer_email || session?.user?.email || "";
-
       const res = await fetch("/api/admin/events", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ...formData,
-          organizer_email: organizerEmail,
-          organizer_user_id: session?.user?.id || null,
           keywords: keywords,
           approval_status: approvalStatus,
         }),

--- a/src/app/(app)/admin/events/page.tsx
+++ b/src/app/(app)/admin/events/page.tsx
@@ -16,9 +16,6 @@ type Event = {
   payment_due_at: string | null;
   approval_status: string;
   created_at: string;
-  organizer_user: {
-    email: string;
-  } | null;
 };
 
 type FilterStatus = "ALL" | "DRAFT" | "PENDING" | "APPROVED" | "REJECTED";
@@ -225,9 +222,6 @@ export default function AdminEventsPage() {
                 <th className="w-32 whitespace-nowrap px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-zinc-700">
                   支払期限
                 </th>
-                <th className="min-w-[180px] px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-zinc-700">
-                  主催者
-                </th>
                 <th className="w-32 whitespace-nowrap px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-zinc-700">
                   作成日
                 </th>
@@ -272,9 +266,6 @@ export default function AdminEventsPage() {
                   </td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm text-zinc-700">
                     {event.payment_due_at ? formatDate(event.payment_due_at) : "-"}
-                  </td>
-                  <td className="px-4 py-3 text-sm text-zinc-600">
-                    {event.organizer_user ? event.organizer_user.email : "-"}
                   </td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm text-zinc-600">
                     {formatDate(event.created_at)}

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -26,13 +26,6 @@ const getCachedEvent = (id: string) =>
           official_urls: true,
           image_url: true,
           approval_status: true,
-          organizer_user: {
-            select: {
-              id: true,
-              email: true,
-              custom_profile_url: true,
-            },
-          },
           entries: {
             select: {
               entry_number: true,

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -82,13 +82,6 @@ export async function GET(request: Request) {
         official_urls: true,
         image_url: true,
         approval_status: true,
-        organizer_user: {
-          select: {
-            id: true,
-            email: true,
-            custom_profile_url: true,
-          },
-        },
         entries: {
           select: {
             entry_number: true,

--- a/src/components/event-form.tsx
+++ b/src/components/event-form.tsx
@@ -29,8 +29,6 @@ export type EventFormData = {
   city: string;
   street_address: string;
   venue_name: string;
-  organizer_email: string;
-  organizer_user_id?: string | null;
   image_url: string;
   official_urls: string[];
   entries: EventEntryData[];
@@ -51,8 +49,6 @@ interface EventFormProps {
   keywords: string[];
   onKeywordsChange: (keywords: string[]) => void;
   children?: React.ReactNode; // ボタン部分を親から受け取る
-  isAdmin?: boolean; // 管理者権限かどうか
-  organizerUsers?: Array<{ id: string; email: string; name: string | null }>; // ORGANIZER権限のユーザー一覧
 }
 
 export default function EventForm({
@@ -61,8 +57,6 @@ export default function EventForm({
   keywords,
   onKeywordsChange,
   children,
-  isAdmin = false,
-  organizerUsers = [],
 }: EventFormProps) {
   const [keywordInput, setKeywordInput] = useState("");
   const [searchingPostalCode, setSearchingPostalCode] = useState(false);
@@ -1119,41 +1113,6 @@ export default function EventForm({
           />
         </div>
       </div>
-
-      {/* 作成者選択（管理者権限の場合のみ） */}
-      {isAdmin && organizerUsers.length > 0 && (
-        <div>
-          <label className="block text-sm font-medium text-zinc-700">
-            作成者（イベント編集権） *
-          </label>
-          <div className="mt-1">
-            <select
-              value={formData.organizer_user_id || ""}
-              onChange={(e) => {
-                const selectedUserId = e.target.value || null;
-                const selectedUser = organizerUsers.find((u) => u.id === selectedUserId);
-                onFormDataChange({
-                  ...formData,
-                  organizer_user_id: selectedUserId,
-                  organizer_email: selectedUser?.email || formData.organizer_email,
-                });
-              }}
-              className="block w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-zinc-900 focus:outline-none focus:ring-1 focus:ring-zinc-900"
-              required
-            >
-              <option value="">選択してください</option>
-              {organizerUsers.map((user) => (
-                <option key={user.id} value={user.id}>
-                  {user.name || user.email} ({user.email})
-                </option>
-              ))}
-            </select>
-            <p className="mt-1 text-xs text-zinc-500">
-              イベントの編集権限を持つユーザーを選択します
-            </p>
-          </div>
-        </div>
-      )}
 
       {children && (
         <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">


### PR DESCRIPTION
# 主催者フィールドを廃止し、イベント登録者フィールドに移行

## 概要
イベントモデルから「主催者」フィールド（`organizer_user_id`, `organizer_user`, `organizer_email`）を廃止し、代わりに「イベント登録者」フィールド（`created_by_user_id`）を使用するように変更しました。イベント登録者はフロントエンドには表示されませんが、データとして保持されます。

## 変更内容

### データベーススキーマ
- ✅ `organizer_user_id`、`organizer_user`リレーション、`organizer_email`フィールドを削除
- ✅ `created_by_user_id`を「イベント登録者」として使用（既存フィールドを活用）
- ✅ マイグレーションで既存の`organizer_user_id`を`created_by_user_id`に自動移行

### API変更
- ✅ `/api/admin/events` (GET): オーガナイザーのフィルタリングを`created_by_user_id`に変更
- ✅ `/api/admin/events` (POST): 主催者関連の処理を削除し、`created_by_user_id`のみを設定
- ✅ `/api/admin/events/[id]` (GET/PATCH): 権限チェックとレスポンスから主催者フィールドを削除
- ✅ `/api/events` (GET): 公開APIから主催者フィールドを削除

### フロントエンド変更
- ✅ イベント一覧ページ: 主催者列を削除
- ✅ イベント詳細ページ: 主催者表示とフォームフィールドを削除
- ✅ イベント新規作成ページ: 主催者関連の処理を削除
- ✅ EventFormコンポーネント: 主催者選択UIを削除

### 権限チェックの変更
- ✅ オーガナイザーの権限チェックを`organizer_user_id`から`created_by_user_id`に変更
- ✅ オーガナイザーは自分が登録したイベントのみアクセス可能

## 既存データの取り扱い

マイグレーション実行時に、以下の処理が行われます：

1. **データ移行**: `organizer_user_id`が設定されていて、`created_by_user_id`がNULLのレコードについて、`organizer_user_id`の値を`created_by_user_id`にコピーします
2. **フィールド削除**: `organizer_email`と`organizer_user_id`カラムを削除します

これにより、既存のイベントの登録者情報が失われることなく保持されます。

## 影響範囲

- イベント管理画面の表示が変更されます（主催者列が削除）
- イベント作成・編集フォームから主催者選択UIが削除されます
- オーガナイザー権限のユーザーは、自分が登録したイベントのみアクセス可能になります

## テスト項目

- [ ] マイグレーションが正常に実行されること
- [ ] 既存の`organizer_user_id`が`created_by_user_id`に正しく移行されること
- [ ] 管理者は全イベントを閲覧できること
- [ ] オーガナイザーは自分が登録したイベントのみ閲覧できること
- [ ] イベント作成時に`created_by_user_id`が正しく設定されること
- [ ] イベント一覧から主催者列が削除されていること

## 関連Issue
<!-- 関連するIssue番号があれば記載 -->

## スクリーンショット
<!-- 必要に応じて追加 -->

## チェックリスト
- [x] コードの変更が完了している
- [x] マイグレーションファイルが作成されている
- [x] ESLintエラーがない
- [x] TypeScriptの型エラーがない
- [x] 既存データの移行処理が含まれている