### PR TITLE
fix: 管理画面の編集キャンセル時にモーダルが閉じない問題を修正

### DIFF
--- a/src/app/(app)/admin/events/[id]/page.tsx
+++ b/src/app/(app)/admin/events/[id]/page.tsx
@@ -269,6 +269,7 @@ export default function AdminEventDetailPage({
 
   const handleConfirmCancel = () => {
     setIsEditing(false);
+    setShowCancelModal(false);
     fetchEvent();
   };
 


### PR DESCRIPTION
## 概要
管理画面で編集をキャンセルした際に、確認モーダルが閉じない問題を修正しました。

## 変更内容
- `src/app/(app)/admin/events/[id]/page.tsx`の`handleConfirmCancel`関数内に`setShowCancelModal(false)`を追加
- 編集キャンセル確認モーダルで「はい」を選択した際に、モーダルが正しく閉じるように修正

## 問題の原因
`handleConfirmCancel`関数内で編集モードを終了する処理（`setIsEditing(false)`）とデータの再取得（`fetchEvent()`）は実行されていましたが、モーダルを閉じる処理（`setShowCancelModal(false)`）が抜けていました。

## 修正内容
const handleConfirmCancel = () => {
  setIsEditing(false);
  setShowCancelModal(false); // 追加
  fetchEvent();
};

## 動作確認
- [x] 編集モードでキャンセルボタンをクリック
- [x] 確認モーダルが表示される
- [x] 「はい」を選択するとモーダルが閉じる
- [x] 編集モードが終了する
- [x] イベントデータが再取得される

## 関連Issue
Fixes #15