### PR TITLE
fix: サイドメニューのモバイル表示改善と視覚的改善

### DIFF
--- a/src/app/(app)/admin/layout.tsx
+++ b/src/app/(app)/admin/layout.tsx
@@ -106,17 +106,18 @@ function SidebarContent({ onLinkClick, pathname, session }: SidebarContentProps)
               );
             })}
         </div>
+        <div className="mt-4 border-t border-zinc-200 pt-4">
+          <div className="mb-2 text-xs text-zinc-600">{session.user.email}</div>
+          <Link
+            href="/app/mypage"
+            className="flex items-center gap-2 text-xs text-zinc-600 hover:text-zinc-900"
+            onClick={onLinkClick}
+          >
+            <span>🔙</span>
+            <span>アプリに戻る</span>
+          </Link>
+        </div>
       </nav>
-      <div className="border-t border-zinc-200 p-4">
-        <div className="mb-2 text-xs text-zinc-600">{session.user.email}</div>
-        <Link
-          href="/app/mypage"
-          className="text-xs text-zinc-600 hover:text-zinc-900"
-          onClick={onLinkClick}
-        >
-          アプリに戻る
-        </Link>
-      </div>
     </div>
   );
 }
@@ -217,7 +218,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
 
       {/* サイドバー（モバイル版 - lg未満でハンバーガーメニュー） */}
       <aside
-        className={`fixed top-0 left-0 z-50 h-screen w-64 border-r border-zinc-200 bg-white transition-transform duration-300 ease-in-out lg:hidden ${isMenuOpen ? "translate-x-0" : "-translate-x-full"
+        className={`fixed top-0 left-0 z-50 h-screen w-64 border-r border-zinc-200 bg-white transition-transform duration-300 ease-in-out lg:hidden overflow-y-auto ${isMenuOpen ? "translate-x-0" : "-translate-x-full"
           }`}
       >
         <div className="flex h-full flex-col">

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -17,14 +17,14 @@ type AppLayoutProps = {
 };
 
 const tabs = [
-  { href: "/app/mypage", label: "マイページ", key: "mypage" },
-  { href: "/events", label: "イベント一覧", key: "events" },
-  { href: "/app/watchlist", label: "ウォッチリスト", key: "watchlist", requiresAuth: true },
-  { href: "/app/reminder", label: "リマインダー管理", key: "reminder", requiresAuth: true },
-  { href: "/app/groups", label: "団体管理", key: "groups", requiresAuth: true },
-  { href: "/app/event-submission", label: "イベント掲載依頼", key: "event-submission" },
-  { href: "/app/organizer-application", label: "オーガナイザー登録申請", key: "organizer-application" },
-  { href: "/app/contact", label: "お問い合わせ", key: "contact" },
+  { href: "/app/mypage", label: "マイページ", key: "mypage", icon: "👤" },
+  { href: "/events", label: "イベント一覧", key: "events", icon: "📅" },
+  { href: "/app/watchlist", label: "ウォッチリスト", key: "watchlist", requiresAuth: true, icon: "⭐" },
+  { href: "/app/reminder", label: "リマインダー管理", key: "reminder", requiresAuth: true, icon: "⏰" },
+  { href: "/app/groups", label: "団体管理", key: "groups", requiresAuth: true, icon: "👥" },
+  { href: "/app/event-submission", label: "イベント掲載依頼", key: "event-submission", icon: "📝" },
+  { href: "/app/organizer-application", label: "オーガナイザー登録申請", key: "organizer-application", icon: "📋" },
+  { href: "/app/contact", label: "お問い合わせ", key: "contact", icon: "💬" },
 ];
 
 function resolveActiveKey(pathname: string) {
@@ -99,7 +99,7 @@ function SideNav({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) 
       )}
       {/* サイドメニュー */}
       <aside
-        className={`fixed top-0 left-0 z-50 flex h-screen w-56 flex-col border-r border-zinc-100 bg-white px-4 py-6 transition-transform duration-300 ease-in-out sm:sticky sm:translate-x-0 ${isOpen ? "translate-x-0" : "-translate-x-full"
+        className={`fixed top-0 left-0 z-50 flex h-screen w-56 flex-col border-r border-zinc-100 bg-white px-4 py-6 transition-transform duration-300 ease-in-out sm:sticky sm:translate-x-0 overflow-y-auto ${isOpen ? "translate-x-0" : "-translate-x-full"
           }`}
       >
         {/* 閉じるボタン（SP版のみ） */}
@@ -193,30 +193,32 @@ function SideNav({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) 
                 key={tab.href}
                 href={tab.href}
                 onClick={(e) => handleNavClick(e, tab.href)}
-                className={`block rounded-lg px-3 py-2 ${isActive
+                className={`flex items-center gap-3 rounded-lg px-3 py-2 ${isActive
                   ? "bg-zinc-900 text-white"
                   : "text-zinc-700 hover:bg-zinc-50"
                   }`}
               >
-                {tab.label}
+                <span>{tab.icon}</span>
+                <span>{tab.label}</span>
               </Link>
             );
           })}
-        </nav>
         {(session?.user?.role === "ADMIN" || session?.user?.role === "ORGANIZER") && (
-          <div className="mt-auto border-t border-zinc-200 pt-4">
+          <div className="mt-4 border-t border-zinc-200 pt-4">
             <Link
               href="/admin/dashboard"
               onClick={(e) => handleNavClick(e, "/admin/dashboard")}
-              className={`block rounded-lg px-3 py-2 text-sm ${pathname?.startsWith("/admin")
+              className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm ${pathname?.startsWith("/admin")
                 ? "bg-zinc-900 text-white"
                 : "text-zinc-700 hover:bg-zinc-50"
                 }`}
             >
-              オーガナイザー機能
+              <span>📊</span>
+              <span>オーガナイザー機能</span>
             </Link>
           </div>
         )}
+        </nav>
       </aside>
     </>
   );


### PR DESCRIPTION
# サイドメニューのモバイル表示改善と視覚的改善

## 概要
スマホ表示時のサイドメニューのUXを改善しました。iOSのブラウザバックコントロールに隠れる問題を解決し、視覚的にわかりやすくするためにアイコンを追加しました。

## 変更内容

### 1. iOSのブラウザバックコントロール対応
- **問題**: サイドメニューを開いたときに、iOSのブラウザバックなどのコントロール部分に下端の項目が隠れてしまう
- **解決策**: 
  - 下端固定（`mt-auto`）を解除し、通常のフローに含めるように変更
  - サイドメニューに`overflow-y-auto`を追加してスクロール可能に

### 2. 管理画面のサイドバー改善
- **ファイル**: `src/app/(app)/admin/layout.tsx`
- **変更内容**:
  - 「アプリに戻る」リンクに戻るアイコン（🔙）を追加
  - 下端固定を解除し、通常のフローに含める
  - スクロール対応を追加

### 3. アプリ側のサイドメニュー改善
- **ファイル**: `src/app/(app)/layout.tsx`
- **変更内容**:
  - 各メニュー項目に絵文字アイコンを追加
    - マイページ: 👤
    - イベント一覧: 📅
    - ウォッチリスト: ⭐
    - リマインダー管理: ⏰
    - 団体管理: 👥
    - イベント掲載依頼: 📝
    - オーガナイザー登録申請: 📋
    - お問い合わせ: 💬
    - オーガナイザー機能: 📊
  - メニュー項目のスタイルを`flex items-center gap-3`に統一
  - 下端固定を解除し、スクロール対応を追加

## 技術的な変更

### レイアウト変更
- `mt-auto`（下端固定）を`mt-4`（通常のマージン）に変更
- `overflow-y-auto`を追加してスクロール可能に

### スタイル統一
- 管理画面とアプリ側のサイドメニューで同じスタイル（`flex items-center gap-3`）を使用
- アイコンとテキストの配置を統一

## テスト項目

- [x] iOSのSafariでサイドメニューを開いたとき、下端の項目がブラウザコントロールに隠れないこと
- [x] サイドメニューの内容が多い場合、スクロールできること
- [x] アプリ側のサイドメニューに絵文字アイコンが正しく表示されること
- [x] 管理画面の「アプリに戻る」に戻るアイコンが表示されること
- [x] メニュー項目のクリックが正常に動作すること
- [x] アクティブなメニュー項目のハイライトが正しく表示されること

## スクリーンショット
（必要に応じて追加）

## 関連Issue
- iOSのブラウザバックコントロールにサイドメニューの項目が隠れる問題

## 備考
- この変更により、モバイルデバイスでのサイドメニューの操作性が向上します
- 絵文字アイコンの追加により、メニュー項目が視覚的に識別しやすくなります