### PR TITLE
fix: マイページでログアウト後にログイン画面に正しくリダイレクトされるように修正

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -160,8 +160,9 @@ function SideNav({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) 
                   // ログアウト処理
                   await signOut({ redirect: false });
 
-                  // 明示的にリダイレクト
-                  router.push(redirectUrl);
+                  // 完全なページリロードを行い、サーバーサイドのミドルウェアが確実に実行されるようにする
+                  // これにより、セッションがクリアされた状態でログインページにアクセスできる
+                  window.location.href = redirectUrl;
                 }}
                 className="mt-2 text-[10px] rounded-md border border-zinc-300 bg-white px-2 py-1 text-zinc-700 hover:bg-zinc-100"
               >


### PR DESCRIPTION
## 概要
マイページでログアウト後にログイン画面に正しくリダイレクトされない問題を修正しました。

## 関連Issue
Closes #48

## 問題の原因
- `signOut({ redirect: false })` の直後に `router.push("/app/auth")` を使用していた
- セッションクッキーが完全に削除される前にクライアントサイドナビゲーションが実行される可能性があった
- その結果、`/app/auth` にアクセスした時点でミドルウェアがまだセッションを検出し、`/app/mypage` にリダイレクトされていた

## 修正内容
- `router.push` を `window.location.href` に変更し、完全なページリロードを実行するように修正
- これにより、サーバーサイドのミドルウェアが確実に実行され、セッションがクリアされた状態でログインページにアクセスできるようになった

## 変更ファイル
- `src/app/(app)/layout.tsx`

## 動作確認
- [x] ログアウト後にログイン画面に正しくリダイレクトされることを確認

## その他
特にありません。