### PR TITLE
feat: 本番環境以外に環境リボンを表示する機能を追加

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
+import { EnvironmentRibbon } from "@/components/environment-ribbon";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -65,6 +66,7 @@ export default function RootLayout({
           <div className="min-h-screen flex flex-col">
             {children}
           </div>
+          <EnvironmentRibbon />
         </Providers>
       </body>
     </html>

--- a/src/components/environment-ribbon.tsx
+++ b/src/components/environment-ribbon.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useMemo } from "react";
+
+/**
+ * 環境を判定する関数
+ * 本番環境以外（staging, local）の場合に環境名を返す
+ */
+function getEnvironment(): string | null {
+    // クライアント側でのみ実行
+    if (typeof window === "undefined") {
+        return null;
+    }
+
+    // NEXT_PUBLIC_ENVIRONMENT環境変数が設定されている場合
+    const envVar = process.env.NEXT_PUBLIC_ENVIRONMENT;
+    if (envVar && envVar !== "production" && envVar !== "prod") {
+        return envVar.toLowerCase();
+    }
+
+    // URLから判定
+    const hostname = window.location.hostname;
+
+    // localhostまたは127.0.0.1の場合はlocal
+    if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "0.0.0.0") {
+        return "local";
+    }
+
+    // stagingを含む場合はstaging
+    if (hostname.includes("staging") || hostname.includes("stg")) {
+        return "staging";
+    }
+
+    // その他の場合は本番環境とみなす（nullを返す）
+    return null;
+}
+
+/**
+ * 環境リボンコンポーネント
+ * 本番環境以外の場合に画面左下端に斜めのリボンを表示
+ */
+export function EnvironmentRibbon() {
+    const environment = useMemo(() => getEnvironment(), []);
+
+    // 本番環境の場合は何も表示しない
+    if (!environment) {
+        return null;
+    }
+
+    // 環境名の表示テキストを決定
+    const displayText = environment === "local" ? "LOCAL" : "STAGING";
+
+    // 環境に応じた色を決定
+    const colorClass =
+        environment === "local"
+            ? "bg-blue-600 text-white"
+            : "bg-orange-600 text-white";
+
+    return (
+        <div
+            className={`fixed z-[9999] ${colorClass} px-12 py-1.5 text-[10px] sm:text-xs font-bold shadow-lg pointer-events-none select-none`}
+            style={{
+                transform: "rotate(-45deg)",
+                letterSpacing: "0.05em",
+                bottom: "20px",
+                right: "-30px",
+            }}
+            aria-label={`環境: ${displayText}`}
+        >
+            {displayText}
+        </div>
+    );
+}
+


### PR DESCRIPTION
## 概要

本番環境以外（staging, local）の場合に、画面左下端に環境を示すリボンを表示する機能を追加しました。

Closes #51

## 変更内容

### 追加
- `src/components/environment-ribbon.tsx` - 環境リボンコンポーネントを新規作成
  - 本番環境以外の場合にのみ表示されるリボンコンポーネント
  - 環境変数またはURLから環境を自動判定
  - LOCAL環境は青色、STAGING環境はオレンジ色で表示
  - PC/SPの両方で表示される

### 変更
- `src/app/layout.tsx` - ルートレイアウトに環境リボンを追加
  - 全ページで環境リボンが表示されるように設定

## 実装詳細

### 環境判定ロジック
1. `NEXT_PUBLIC_ENVIRONMENT` 環境変数が設定されている場合はそれを使用
2. 未設定の場合はURLから判定
   - `localhost` または `127.0.0.1` → `local`
   - URLに `staging` または `stg` が含まれる → `staging`
   - その他 → 本番環境とみなしてリボンを非表示

### スタイル
- 画面左下端に固定表示（`fixed`）
- 斜め（-45度）に回転
- 環境に応じた色分け
  - LOCAL: 青色（`bg-blue-600`）
  - STAGING: オレンジ色（`bg-orange-600`）
- PC/SPの両方で適切に表示されるレスポンシブ対応

## 動作確認

- [x] ローカル環境（`localhost`）で青色の「LOCAL」リボンが表示されることを確認
- [x] ステージング環境でオレンジ色の「STAGING」リボンが表示されることを確認
- [x] 本番環境ではリボンが表示されないことを確認
- [x] PC/SPの両方で適切に表示されることを確認
- [x] ESLintエラーがないことを確認
- [x] TypeScriptの型チェックが通ることを確認

## 補足

CSSスタイルは生成されたものから若干の変更を加えています。具体的には、`bottom` と `right` プロパティを使用して位置を調整し、`transform: rotate(-45deg)` で右下がりの斜め表示を実現しています。