### PR TITLE
feat: イベントエントリー日時をJST表示に修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@prisma/client": "^7.0.0",
         "@types/web-push": "^3.6.4",
         "bcryptjs": "^3.0.3",
+        "dayjs": "^1.11.19",
         "emoji-picker-react": "^4.16.1",
         "mariadb": "^3.4.5",
         "mysql2": "^3.15.3",
@@ -8483,6 +8484,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.19",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
+      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@prisma/client": "^7.0.0",
     "@types/web-push": "^3.6.4",
     "bcryptjs": "^3.0.3",
+    "dayjs": "^1.11.19",
     "emoji-picker-react": "^4.16.1",
     "mariadb": "^3.4.5",
     "mysql2": "^3.15.3",

--- a/src/app/(app)/admin/events/[id]/page.tsx
+++ b/src/app/(app)/admin/events/[id]/page.tsx
@@ -9,6 +9,7 @@ import ConfirmModal from "@/components/confirm-modal";
 import { Button } from "@/components/button";
 import { LoadingSpinner } from "@/components/loading-spinner";
 import { EventShareModal } from "@/components/event-share-modal";
+import { formatDate, formatDateTime } from "@/lib/date-utils";
 
 type Event = {
   id: string;
@@ -589,10 +590,10 @@ export default function AdminEventDetailPage({
             <div>
               <h3 className="text-sm font-medium text-zinc-700">開催日</h3>
               <p className="mt-1 text-sm text-zinc-600">
-                {new Date(event.event_date).toLocaleDateString("ja-JP")}
+                {formatDate(event.event_date)}
                 {event.is_multi_day && event.event_end_date && (
                   <span className="ml-2">
-                    〜 {new Date(event.event_end_date).toLocaleDateString("ja-JP")}
+                    〜 {formatDate(event.event_end_date)}
                   </span>
                 )}
               </p>
@@ -632,12 +633,12 @@ export default function AdminEventDetailPage({
                       <div className="space-y-2 text-xs text-zinc-600">
                         <div>
                           <span className="font-medium">エントリー開始日時:</span>{" "}
-                          {new Date(entry.entry_start_at).toLocaleString("ja-JP")}
+                          {formatDateTime(entry.entry_start_at)}
                         </div>
                         <div>
                           <span className="font-medium">エントリー開始日時公開日時:</span>{" "}
                           {entry.entry_start_public_at ? (
-                            <span>{new Date(entry.entry_start_public_at).toLocaleString("ja-JP")}</span>
+                            <span>{formatDateTime(entry.entry_start_public_at)}</span>
                           ) : (
                             <span className="text-zinc-500">未設定（即時公開）</span>
                           )}
@@ -645,7 +646,7 @@ export default function AdminEventDetailPage({
                         <div>
                           <span className="font-medium">エントリー締切日時:</span>{" "}
                           {entry.entry_deadline_at ? (
-                            <span>{new Date(entry.entry_deadline_at).toLocaleString("ja-JP")}</span>
+                            <span>{formatDateTime(entry.entry_deadline_at)}</span>
                           ) : (
                             <span className="text-zinc-500">未設定</span>
                           )}
@@ -653,7 +654,7 @@ export default function AdminEventDetailPage({
                         <div>
                           <span className="font-medium">支払期限日時:</span>{" "}
                           {entry.payment_due_at
-                            ? new Date(entry.payment_due_at).toLocaleString("ja-JP")
+                            ? formatDateTime(entry.payment_due_at)
                             : entry.payment_due_type === "RELATIVE" && entry.payment_due_days_after_entry
                               ? `エントリー申し込みから${entry.payment_due_days_after_entry}日以内`
                               : "未設定"}
@@ -661,7 +662,7 @@ export default function AdminEventDetailPage({
                         <div>
                           <span className="font-medium">支払期限日時公開日時:</span>{" "}
                           {entry.payment_due_public_at ? (
-                            <span>{new Date(entry.payment_due_public_at).toLocaleString("ja-JP")}</span>
+                            <span>{formatDateTime(entry.payment_due_public_at)}</span>
                           ) : (
                             <span className="text-zinc-500">未設定（即時公開）</span>
                           )}

--- a/src/app/(app)/admin/events/page.tsx
+++ b/src/app/(app)/admin/events/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/button";
 import { LoadingSpinner } from "@/components/loading-spinner";
+import { formatDate, formatDateTime } from "@/lib/date-utils";
 
 type Event = {
   id: string;
@@ -93,13 +94,6 @@ export default function AdminEventsPage() {
     }
   };
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString("ja-JP", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
-  };
 
   return (
     <div className="w-full px-4 py-4 sm:px-6 sm:py-6 lg:px-8 lg:py-8">
@@ -262,10 +256,10 @@ export default function AdminEventsPage() {
                     {formatDate(event.event_date)}
                   </td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm text-zinc-700">
-                    {event.entry_start_at ? formatDate(event.entry_start_at) : "-"}
+                    {event.entry_start_at ? formatDateTime(event.entry_start_at) : "-"}
                   </td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm text-zinc-700">
-                    {event.payment_due_at ? formatDate(event.payment_due_at) : "-"}
+                    {event.payment_due_at ? formatDateTime(event.payment_due_at) : "-"}
                   </td>
                   <td className="whitespace-nowrap px-4 py-3 text-sm text-zinc-600">
                     {formatDate(event.created_at)}

--- a/src/app/(app)/admin/submissions/page.tsx
+++ b/src/app/(app)/admin/submissions/page.tsx
@@ -5,6 +5,7 @@ import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/button";
 import { LoadingSpinner } from "@/components/loading-spinner";
+import { formatDate, formatDateTime } from "@/lib/date-utils";
 
 type Submission = {
   id: string;
@@ -146,14 +147,6 @@ export default function AdminSubmissionsPage() {
     }
   };
 
-  const formatDate = (dateString: string | null) => {
-    if (!dateString) return "未定";
-    return new Date(dateString).toLocaleDateString("ja-JP", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
-  };
 
   return (
     <div className="w-full px-4 py-4 sm:px-6 sm:py-6 lg:px-8 lg:py-8">
@@ -280,11 +273,11 @@ export default function AdminSubmissionsPage() {
                     )}
                     {submission.entry_start_at && (
                       <span>
-                        エントリー開始: {formatDate(submission.entry_start_at)}
+                        エントリー開始: {formatDateTime(submission.entry_start_at)}
                       </span>
                     )}
                     {submission.payment_due_at && (
-                      <span>支払期限: {formatDate(submission.payment_due_at)}</span>
+                      <span>支払期限: {formatDateTime(submission.payment_due_at)}</span>
                     )}
                     <span>提出日: {formatDate(submission.created_at)}</span>
                   </div>
@@ -391,18 +384,18 @@ export default function AdminSubmissionsPage() {
 
                 {selectedSubmission.entry_start_at && (
                   <div>
-                    <h3 className="text-sm font-medium text-zinc-700">エントリー開始日</h3>
+                    <h3 className="text-sm font-medium text-zinc-700">エントリー開始日時</h3>
                     <p className="mt-1 text-sm text-zinc-600">
-                      {formatDate(selectedSubmission.entry_start_at)}
+                      {formatDateTime(selectedSubmission.entry_start_at)}
                     </p>
                   </div>
                 )}
 
                 {selectedSubmission.payment_due_at && (
                   <div>
-                    <h3 className="text-sm font-medium text-zinc-700">支払期限</h3>
+                    <h3 className="text-sm font-medium text-zinc-700">支払期限日時</h3>
                     <p className="mt-1 text-sm text-zinc-600">
-                      {formatDate(selectedSubmission.payment_due_at)}
+                      {formatDateTime(selectedSubmission.payment_due_at)}
                     </p>
                   </div>
                 )}

--- a/src/app/(app)/app/reminder/page.tsx
+++ b/src/app/(app)/app/reminder/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import ConfirmModal from "@/components/confirm-modal";
 import { LoadingSpinner } from "@/components/loading-spinner";
 import { ReminderCard } from "@/components/reminder-card";
+import { formatDateTime } from "@/lib/date-utils";
 
 type Reminder = {
   id: string;
@@ -23,16 +24,6 @@ type Reminder = {
   notified_at: string | null;
   created_at: string;
 };
-
-function formatDateTime(dateString: string) {
-  return new Intl.DateTimeFormat("ja-JP", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(new Date(dateString));
-}
 
 export default function ReminderPage() {
   const [reminders, setReminders] = useState<Reminder[]>([]);

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -3,6 +3,7 @@
 import { SafeMessageContent } from "@/components/safe-message-content";
 import { MessageReactions } from "@/components/message-reactions";
 import { useRef } from "react";
+import { formatDateTime } from "@/lib/date-utils";
 
 type MessageBubbleProps = {
   messageId: string;
@@ -37,16 +38,6 @@ const truncateName = (name: string | null, maxLength: number = 12): string => {
   const nameArray = Array.from(name);
   if (nameArray.length <= maxLength) return name;
   return nameArray.slice(0, maxLength).join("") + "...";
-};
-
-const formatDateTime = (dateString: string) => {
-  const date = new Date(dateString);
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  const hours = String(date.getHours()).padStart(2, "0");
-  const minutes = String(date.getMinutes()).padStart(2, "0");
-  return `${year}/${month}/${day} ${hours}:${minutes}`;
 };
 
 export function MessageBubble({

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -1,0 +1,134 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+
+// dayjsプラグインを拡張
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+/**
+ * 日時のロケール設定
+ * 将来的に多言語対応を可能にするための型定義
+ */
+export type DateLocale = "ja-JP" | "en-US";
+
+/**
+ * デフォルトのタイムゾーン（JST）
+ */
+const DEFAULT_TIMEZONE = "Asia/Tokyo";
+
+/**
+ * 日時をJSTに変換する
+ */
+function toJST(date: string | Date | dayjs.Dayjs): dayjs.Dayjs {
+  return dayjs(date).tz(DEFAULT_TIMEZONE);
+}
+
+/**
+ * ロケールに応じた日付フォーマットを取得
+ * @param locale ロケール（デフォルト: "ja-JP"）
+ * @returns 日付フォーマット文字列
+ */
+function getDateFormat(locale: DateLocale = "ja-JP"): string {
+  switch (locale) {
+    case "ja-JP":
+      return "YYYY年MM月DD日";
+    case "en-US":
+      return "MMM DD, YYYY";
+    default:
+      return "YYYY年MM月DD日";
+  }
+}
+
+/**
+ * ロケールに応じた日時フォーマットを取得
+ * @param locale ロケール（デフォルト: "ja-JP"）
+ * @returns 日時フォーマット文字列
+ */
+function getDateTimeFormat(locale: DateLocale = "ja-JP"): string {
+  switch (locale) {
+    case "ja-JP":
+      return "YYYY年MM月DD日 HH:mm";
+    case "en-US":
+      return "MMM DD, YYYY HH:mm";
+    default:
+      return "YYYY年MM月DD日 HH:mm";
+  }
+}
+
+/**
+ * 日付のみをフォーマット（年月日のみ）
+ * @param date 日付（文字列、Dateオブジェクト、またはdayjsオブジェクト）
+ * @param locale ロケール（デフォルト: "ja-JP"）
+ * @returns フォーマットされた日付文字列
+ */
+export function formatDate(
+  date: string | Date | dayjs.Dayjs | null | undefined,
+  locale: DateLocale = "ja-JP"
+): string {
+  if (!date) {
+    return "";
+  }
+
+  try {
+    const jstDate = toJST(date);
+    if (!jstDate.isValid()) {
+      return "";
+    }
+    return jstDate.format(getDateFormat(locale));
+  } catch (error) {
+    console.error("Error formatting date:", error);
+    return "";
+  }
+}
+
+/**
+ * 日時をフォーマット（年月日と時間、秒は含まない）
+ * @param date 日時（文字列、Dateオブジェクト、またはdayjsオブジェクト）
+ * @param locale ロケール（デフォルト: "ja-JP"）
+ * @returns フォーマットされた日時文字列
+ */
+export function formatDateTime(
+  date: string | Date | dayjs.Dayjs | null | undefined,
+  locale: DateLocale = "ja-JP"
+): string {
+  if (!date) {
+    return "";
+  }
+
+  try {
+    const jstDate = toJST(date);
+    if (!jstDate.isValid()) {
+      return "";
+    }
+    return jstDate.format(getDateTimeFormat(locale));
+  } catch (error) {
+    console.error("Error formatting datetime:", error);
+    return "";
+  }
+}
+
+/**
+ * 日付範囲をフォーマット（複数日開催用）
+ * @param startDate 開始日
+ * @param endDate 終了日（オプション）
+ * @param locale ロケール（デフォルト: "ja-JP"）
+ * @returns フォーマットされた日付範囲文字列
+ */
+export function formatDateRange(
+  startDate: string | Date | dayjs.Dayjs | null | undefined,
+  endDate: string | Date | dayjs.Dayjs | null | undefined,
+  locale: DateLocale = "ja-JP"
+): string {
+  if (!startDate) {
+    return "";
+  }
+
+  const start = formatDate(startDate, locale);
+  if (!endDate) {
+    return start;
+  }
+
+  const end = formatDate(endDate, locale);
+  return locale === "ja-JP" ? `${start} 〜 ${end}` : `${start} - ${end}`;
+}


### PR DESCRIPTION
## 概要
イベントエントリー日時をJST（日本標準時）表示に修正しました。これにより、ユーザーが日時を正確に理解できるようになります。

## 変更内容
- `date-utils.ts`を新規追加し、日時フォーマット用のユーティリティ関数を実装
  - `formatDate`: 日付のみをフォーマット（年月日）
  - `formatDateTime`: 日時をフォーマット（年月日と時間）
  - `formatDateRange`: 日付範囲をフォーマット（複数日開催用）
  - すべての関数でJST（Asia/Tokyo）への変換を自動実行
  - 将来的な多言語対応を見据えたロケール対応（現在は日本語のみ）

- 以下のページでJST表示に対応
  - 管理画面のイベント一覧ページ (`admin/events/page.tsx`)
  - 管理画面のイベント詳細ページ (`admin/events/[id]/page.tsx`)
  - 提出物管理ページ (`admin/submissions/page.tsx`)
  - リマインダーページ (`app/reminder/page.tsx`)
  - メッセージバブルコンポーネント (`components/message-bubble.tsx`)

## 技術的な変更
- `dayjs`の`utc`と`timezone`プラグインを使用してタイムゾーン変換を実装
- エラーハンドリングを追加（無効な日時の場合は空文字を返す）
- 既存の`Intl.DateTimeFormat`を使用していた箇所を新しいユーティリティ関数に置き換え

## テスト
- [x] TypeScriptの型チェックがパス
- [x] ESLintのチェックがパス
- [x] 各ページで日時が正しくJSTで表示されることを確認

## 関連Issue
fix #14