### PR TITLE
fix: ユーザー物理削除時の外部キー制約エラーを修正

### DIFF
--- a/prisma/migrations/20260124120000_fix_user_delete_cascade_constraints/migration.sql
+++ b/prisma/migrations/20260124120000_fix_user_delete_cascade_constraints/migration.sql
@@ -1,0 +1,13 @@
+-- AlterTable: user_eventsのuser_id外部キー制約をRESTRICTからCASCADEに変更
+ALTER TABLE `user_events` DROP FOREIGN KEY `user_events_user_id_fkey`;
+ALTER TABLE `user_events` ADD CONSTRAINT `user_events_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AlterTable: group_messagesのsender_id外部キー制約をRESTRICTからCASCADEに変更
+ALTER TABLE `group_messages` DROP FOREIGN KEY `group_messages_sender_id_fkey`;
+ALTER TABLE `group_messages` ADD CONSTRAINT `group_messages_sender_id_fkey` FOREIGN KEY (`sender_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AlterTable: event_followsのuser_id外部キー制約をRESTRICTからCASCADEに変更
+ALTER TABLE `event_follows` DROP FOREIGN KEY `event_follows_user_id_fkey`;
+ALTER TABLE `event_follows` ADD CONSTRAINT `event_follows_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Note: groupsのleader_user_idは物理削除処理で手動でリーダーを変更するため、CASCADEに変更しない

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -149,7 +149,7 @@ model UserEvent {
   updated_at        DateTime @updatedAt
   event             Event    @relation(fields: [event_id], references: [id])
   group             Group?   @relation(fields: [group_id], references: [id])
-  user              User     @relation(fields: [user_id], references: [id])
+  user              User     @relation(fields: [user_id], references: [id], onDelete: Cascade)
 
   @@id([user_id, event_id])
   @@index([event_id], map: "user_events_event_id_fkey")
@@ -190,7 +190,7 @@ model GroupMessage {
   reactions       GroupMessageReaction[]
   reads           GroupMessageRead[]
   group           Group                  @relation(fields: [group_id], references: [id])
-  sender          User                   @relation("GroupMessageSender", fields: [sender_id], references: [id])
+  sender          User                   @relation("GroupMessageSender", fields: [sender_id], references: [id], onDelete: Cascade)
 
   @@index([group_id], map: "group_messages_group_id_fkey")
   @@index([sender_id], map: "group_messages_sender_id_fkey")
@@ -252,7 +252,7 @@ model EventFollow {
   event_id    String   @db.VarChar(36)
   followed_at DateTime @default(now())
   event       Event    @relation(fields: [event_id], references: [id])
-  user        User     @relation(fields: [user_id], references: [id])
+  user        User     @relation(fields: [user_id], references: [id], onDelete: Cascade)
 
   @@id([user_id, event_id])
   @@index([event_id], map: "event_follows_event_id_fkey")

--- a/src/lib/user-utils.ts
+++ b/src/lib/user-utils.ts
@@ -1,0 +1,89 @@
+import { prisma } from "@/lib/prisma";
+
+/**
+ * ユーザーがリーダーになっているグループのリーダー権限を移譲する
+ * メンバーがいない場合はグループを削除する
+ * 
+ * @param userId 削除対象のユーザーID
+ * @param options エラーハンドリングのオプション
+ * @returns エラーが発生した場合、エラー情報を返す。成功時はnull
+ */
+export async function transferGroupLeadership(
+  userId: string,
+  options: {
+    /**
+     * エラー時に例外を投げるかどうか
+     * trueの場合、エラー時に例外を投げる（論理削除時など）
+     * falseの場合、エラーをログに記録して続行（物理削除時など）
+     */
+    throwOnError?: boolean;
+  } = {}
+): Promise<{ groupId: string; groupName: string; message: string } | null> {
+  const { throwOnError = false } = options;
+
+  // リーダーになっているグループを検索
+  const groupsLeading = await prisma.group.findMany({
+    where: { leader_user_id: userId },
+    select: {
+      id: true,
+      name: true,
+    },
+  });
+
+  for (const group of groupsLeading) {
+    // グループのメンバーを加入日時順（created_at昇順）で取得
+    const groupMembers = await prisma.userGroup.findMany({
+      where: {
+        group_id: group.id,
+        // 削除対象のユーザーは除外
+        user_id: { not: userId },
+      },
+      orderBy: {
+        created_at: "asc",
+      },
+      select: {
+        user_id: true,
+      },
+    });
+
+    if (groupMembers.length === 0) {
+      // メンバーがいない場合はグループを削除
+      try {
+        await prisma.group.delete({
+          where: { id: group.id },
+        });
+      } catch (groupDeleteError) {
+        console.error("Error deleting group:", groupDeleteError);
+        // グループ削除に失敗しても続行（後で手動で削除可能）
+      }
+      continue;
+    }
+
+    // 加入日時が一番早いメンバーを新しいリーダーに設定
+    const newLeaderId = groupMembers[0].user_id;
+
+    try {
+      await prisma.group.update({
+        where: { id: group.id },
+        data: { leader_user_id: newLeaderId },
+      });
+    } catch (leaderUpdateError) {
+      const errorMessage = leaderUpdateError instanceof Error
+        ? leaderUpdateError.message
+        : String(leaderUpdateError);
+
+      console.error("Error transferring leadership:", leaderUpdateError);
+
+      if (throwOnError) {
+        return {
+          groupId: group.id,
+          groupName: group.name,
+          message: errorMessage,
+        };
+      }
+      // throwOnErrorがfalseの場合は続行（論理削除時に移譲済みの可能性がある）
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## 概要
本番環境でユーザーの物理削除（完全削除）ができない問題を修正しました。外部キー制約エラーが原因でした。

## 問題
- ユーザーの論理削除は成功するが、物理削除ができない
- エラーコード: `P2003` (外部キー制約違反)
- 原因: `user_events`, `group_messages`, `event_follows`テーブルの外部キー制約が`ON DELETE RESTRICT`になっていた

## 解決策
1. **外部キー制約の変更**
   - `user_events.user_id` → `ON DELETE CASCADE`
   - `group_messages.sender_id` → `ON DELETE CASCADE`
   - `event_follows.user_id` → `ON DELETE CASCADE`

2. **グループリーダー削除時の処理**
   - 論理削除時に、加入日時が最も早いメンバーにリーダー権限を委譲
   - メンバーがいない場合はグループを削除
   - 物理削除時は念のため再度確認（論理削除時に移譲済みのはず）

3. **コードのリファクタリング**
   - リーダー権限移譲処理を`src/lib/user-utils.ts`に共通化
   - 可読性とメンテナンス性を向上

## 変更内容
- `prisma/schema.prisma`: 外部キー制約に`onDelete: Cascade`を追加
- `prisma/migrations/20260124120000_fix_user_delete_cascade_constraints/migration.sql`: マイグレーション作成
- `src/app/api/admin/users/[id]/delete/route.ts`: 論理削除時にリーダー権限移譲処理を追加
- `src/app/api/admin/users/[id]/permanent-delete/route.ts`: 物理削除時の処理を改善
- `src/lib/user-utils.ts`: リーダー権限移譲処理を共通化（新規作成）

## テスト
- [x] 論理削除が正常に動作することを確認
- [x] 物理削除が正常に動作することを確認
- [x] グループリーダー削除時にリーダー権限が移譲されることを確認
- [x] メンバーがいないグループが削除されることを確認

## マイグレーション
本番環境で以下のコマンドを実行してください：
`npx prisma migrate deploy`

## 注意事項
- groups.leader_user_idはCASCADEに変更していません（リーダー削除時にグループを削除しないため）
- 論理削除時にリーダー権限移譲が実行されます
- 物理削除時は念のため再度確認しますが、論理削除時に移譲済みのはずです
